### PR TITLE
fix: pass project_dir as working directory to Claude Code subprocess

### DIFF
--- a/src/mcp_coder/cli/commands/prompt.py
+++ b/src/mcp_coder/cli/commands/prompt.py
@@ -152,6 +152,7 @@ def execute_prompt(args: argparse.Namespace) -> int:
                 timeout=timeout,
                 session_id=resume_session_id,
                 env_vars=env_vars,
+                project_dir=str(project_dir),
             )
             # Output complete response as JSON (includes session_id)
             formatted_output = json.dumps(response_dict, indent=2, default=str)
@@ -165,6 +166,7 @@ def execute_prompt(args: argparse.Namespace) -> int:
                 timeout=timeout,
                 session_id=resume_session_id,
                 env_vars=env_vars,
+                project_dir=str(project_dir),
             )
 
             # Simple text output with tool summary
@@ -183,7 +185,7 @@ def execute_prompt(args: argparse.Namespace) -> int:
         else:
             # Use detailed API for verbose/raw modes that need metadata
             response_data = ask_claude_code_api_detailed_sync(
-                args.prompt, timeout, resume_session_id, env_vars
+                args.prompt, timeout, resume_session_id, env_vars, str(project_dir)
             )
 
             # Store response if requested

--- a/src/mcp_coder/llm/interface.py
+++ b/src/mcp_coder/llm/interface.py
@@ -23,6 +23,7 @@ def ask_llm(
     session_id: str | None = None,
     timeout: int = LLM_DEFAULT_TIMEOUT_SECONDS,
     env_vars: dict[str, str] | None = None,
+    project_dir: str | None = None,
 ) -> str:
     """
     Ask a question to an LLM provider using the specified method.
@@ -42,6 +43,7 @@ def ask_llm(
                    for full session management capabilities.
         timeout: Timeout in seconds for the request (default: 30)
         env_vars: Optional environment variables to pass to the LLM subprocess
+        project_dir: Optional project directory to use as working directory for the LLM subprocess
 
     Returns:
         The LLM's response text as a string
@@ -82,6 +84,7 @@ def ask_llm(
             session_id=session_id,
             timeout=timeout,
             env_vars=env_vars,
+            cwd=project_dir,
         )
     else:
         raise ValueError(
@@ -96,6 +99,7 @@ def prompt_llm(
     session_id: str | None = None,
     timeout: int = LLM_DEFAULT_TIMEOUT_SECONDS,
     env_vars: dict[str, str] | None = None,
+    project_dir: str | None = None,
 ) -> LLMResponseDict:
     """
     Ask a question to an LLM provider with full session management.
@@ -112,6 +116,7 @@ def prompt_llm(
         session_id: Optional session ID to resume previous conversation
         timeout: Timeout in seconds for the request (default: 30)
         env_vars: Optional environment variables to pass to the LLM subprocess
+        project_dir: Optional project directory to use as working directory for the LLM subprocess
 
     Returns:
         LLMResponseDict containing:
@@ -164,11 +169,19 @@ def prompt_llm(
     if provider == "claude":
         if method == "cli":
             return ask_claude_code_cli(
-                question, session_id=session_id, timeout=timeout, env_vars=env_vars
+                question,
+                session_id=session_id,
+                timeout=timeout,
+                env_vars=env_vars,
+                cwd=project_dir,
             )
         elif method == "api":
             return ask_claude_code_api(
-                question, session_id=session_id, timeout=timeout, env_vars=env_vars
+                question,
+                session_id=session_id,
+                timeout=timeout,
+                env_vars=env_vars,
+                cwd=project_dir,
             )
         else:
             raise ValueError(

--- a/src/mcp_coder/llm/providers/claude/claude_code_cli.py
+++ b/src/mcp_coder/llm/providers/claude/claude_code_cli.py
@@ -167,6 +167,7 @@ def ask_claude_code_cli(
     session_id: str | None = None,
     timeout: int = 30,
     env_vars: dict[str, str] | None = None,
+    cwd: str | None = None,
 ) -> LLMResponseDict:
     """Ask Claude via CLI with native session support.
 
@@ -178,6 +179,7 @@ def ask_claude_code_cli(
         session_id: Optional Claude session ID to resume previous conversation
         timeout: Timeout in seconds (default: 30)
         env_vars: Optional environment variables for the subprocess
+        cwd: Optional working directory for the subprocess
 
     Returns:
         LLMResponseDict with complete response data including session_id
@@ -216,6 +218,7 @@ def ask_claude_code_cli(
         timeout_seconds=timeout,
         input_data=question,  # Pass question via stdin
         env=env_vars,
+        cwd=cwd,  # Set working directory to match MCP server configuration
     )
     result = execute_subprocess(command, options)
 

--- a/src/mcp_coder/llm/providers/claude/claude_code_interface.py
+++ b/src/mcp_coder/llm/providers/claude/claude_code_interface.py
@@ -10,6 +10,7 @@ def ask_claude_code(
     session_id: str | None = None,
     timeout: int = 30,
     env_vars: dict[str, str] | None = None,
+    cwd: str | None = None,
 ) -> str:
     """
     Ask Claude a question using the specified implementation method.
@@ -26,6 +27,7 @@ def ask_claude_code(
         session_id: Optional session ID to resume previous conversation
         timeout: Timeout in seconds for the request (default: 30)
         env_vars: Optional environment variables to pass to the LLM subprocess
+        cwd: Optional working directory for the LLM subprocess
 
     Returns:
         Claude's response text as a string
@@ -53,12 +55,12 @@ def ask_claude_code(
 
     if method == "cli":
         result = ask_claude_code_cli(
-            question, session_id=session_id, timeout=timeout, env_vars=env_vars
+            question, session_id=session_id, timeout=timeout, env_vars=env_vars, cwd=cwd
         )
         return result["text"]  # Extract text from LLMResponseDict
     elif method == "api":
         result = ask_claude_code_api(
-            question, session_id=session_id, timeout=timeout, env_vars=env_vars
+            question, session_id=session_id, timeout=timeout, env_vars=env_vars, cwd=cwd
         )
         return result["text"]  # Extract text from LLMResponseDict
     else:

--- a/src/mcp_coder/utils/commit_operations.py
+++ b/src/mcp_coder/utils/commit_operations.py
@@ -108,6 +108,7 @@ def generate_commit_message_with_llm(
             method=method,
             timeout=LLM_COMMIT_TIMEOUT_SECONDS,
             env_vars=env_vars,
+            project_dir=str(project_dir),
         )
 
         if not response or not response.strip():

--- a/src/mcp_coder/workflows/implement/core.py
+++ b/src/mcp_coder/workflows/implement/core.py
@@ -86,6 +86,7 @@ def prepare_task_tracker(project_dir: Path, provider: str, method: str) -> bool:
             method=method,
             timeout=300,
             env_vars=env_vars,
+            project_dir=str(project_dir),
         )
 
         if not response or not response.strip():

--- a/src/mcp_coder/workflows/implement/task_processing.py
+++ b/src/mcp_coder/workflows/implement/task_processing.py
@@ -106,6 +106,7 @@ def _call_llm_with_comprehensive_capture(
     method: str,
     timeout: int = 300,
     env_vars: dict[str, str] | None = None,
+    cwd: str | None = None,
 ) -> tuple[str, dict[Any, Any]]:
     """Call LLM and capture both text response and comprehensive data.
 
@@ -115,6 +116,7 @@ def _call_llm_with_comprehensive_capture(
         method: LLM method (e.g., 'cli' or 'api')
         timeout: Request timeout in seconds
         env_vars: Optional environment variables for the subprocess
+        cwd: Optional working directory for the LLM subprocess
 
     Returns:
         Tuple of (response_text, comprehensive_data_dict)
@@ -131,7 +133,7 @@ def _call_llm_with_comprehensive_capture(
             )
             start_time = datetime.now()
             detailed_response = ask_claude_code_api_detailed_sync(
-                prompt, timeout=timeout, env_vars=env_vars
+                prompt, timeout=timeout, env_vars=env_vars, cwd=cwd
             )
             duration = (datetime.now() - start_time).total_seconds()
             logger.info(f"Claude API call completed in {duration:.1f}s")
@@ -178,6 +180,7 @@ def _call_llm_with_comprehensive_capture(
                 method=method,
                 timeout=timeout,
                 env_vars=env_vars,
+                project_dir=cwd,
             )
             return response_text, {}
         except subprocess.TimeoutExpired as e:
@@ -439,6 +442,7 @@ def check_and_fix_mypy(
                         method,
                         timeout=LLM_IMPLEMENTATION_TIMEOUT_SECONDS,
                         env_vars=env_vars,
+                        cwd=str(project_dir),
                     )
                 )
 
@@ -520,6 +524,9 @@ def process_single_task(
     # Prepare environment variables for LLM subprocess
     env_vars = prepare_llm_environment(project_dir)
 
+    # Set working directory for LLM subprocess
+    cwd = str(project_dir)
+
     # Get next incomplete task
     next_task = get_next_task(project_dir)
     if not next_task:
@@ -552,6 +559,7 @@ Please implement this task step by step."""
             method,
             timeout=LLM_IMPLEMENTATION_TIMEOUT_SECONDS,
             env_vars=env_vars,
+            cwd=cwd,
         )
 
         if not response or not response.strip():

--- a/tests/cli/commands/test_prompt.py
+++ b/tests/cli/commands/test_prompt.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 from pathlib import Path
+from unittest import mock
 from unittest.mock import Mock, mock_open, patch
 
 import pytest
@@ -36,6 +37,7 @@ class TestExecutePrompt:
             timeout=30,
             session_id=None,
             env_vars={"MCP_CODER_PROJECT_DIR": "/test"},
+            project_dir=mock.ANY,
         )
         captured = capsys.readouterr()
         assert "The capital of France is Paris." in captured.out
@@ -97,6 +99,7 @@ class TestExecutePrompt:
             timeout=30,
             session_id="previous-session-456",
             env_vars={"MCP_CODER_PROJECT_DIR": "/test"},
+            project_dir=mock.ANY,
         )
         captured = capsys.readouterr()
         assert "Adding error handling." in captured.out
@@ -132,6 +135,7 @@ class TestExecutePrompt:
             timeout=30,
             session_id=None,
             env_vars={"MCP_CODER_PROJECT_DIR": "/test"},
+            project_dir=mock.ANY,
         )
         captured = capsys.readouterr()
         assert (
@@ -172,6 +176,7 @@ class TestExecutePrompt:
             timeout=30,
             session_id=None,
             env_vars={"MCP_CODER_PROJECT_DIR": "/test"},
+            project_dir=mock.ANY,
         )
         captured = capsys.readouterr()
         assert (
@@ -214,6 +219,7 @@ class TestExecutePrompt:
             timeout=30,
             session_id=None,
             env_vars={"MCP_CODER_PROJECT_DIR": "/test"},
+            project_dir=mock.ANY,
         )
         captured = capsys.readouterr()
         assert "Warning: No session_id found" in captured.out
@@ -262,6 +268,7 @@ class TestExecutePrompt:
             30,
             "verbose-continuation-123",
             {"MCP_CODER_PROJECT_DIR": "/test"},
+            mock.ANY,
         )
         captured = capsys.readouterr()
         assert "Here are some advanced Python features." in captured.out
@@ -301,6 +308,7 @@ class TestExecutePrompt:
             timeout=30,
             session_id=None,
             env_vars=mock_env_vars,
+            project_dir=mock.ANY,
         )
         captured = capsys.readouterr()
         assert "Response with env vars." in captured.out
@@ -334,6 +342,7 @@ class TestExecutePrompt:
             timeout=30,
             session_id=None,
             env_vars=None,
+            project_dir=mock.ANY,
         )
         captured = capsys.readouterr()
         assert "Response without env vars." in captured.out

--- a/tests/llm/providers/claude/test_claude_code_api.py
+++ b/tests/llm/providers/claude/test_claude_code_api.py
@@ -41,7 +41,7 @@ class TestCreateClaudeClient:
 
             # Verify
             mock_verify.assert_not_called()
-            mock_options_class.assert_called_once_with(env={})
+            mock_options_class.assert_called_once_with(env={}, cwd=None)
             assert result == mock_options
 
     def test_create_claude_client_sdk_failure_triggers_verification(self) -> None:
@@ -92,7 +92,7 @@ class TestCreateClaudeClient:
 
             # Verify
             mock_verify.assert_not_called()
-            mock_options_class.assert_called_once_with(env=env_vars)
+            mock_options_class.assert_called_once_with(env=env_vars, cwd=None)
             assert result == mock_options
 
 
@@ -295,7 +295,9 @@ class TestAskClaudeCodeApi:
         # Verify - now returns dict, not string
         assert isinstance(result, dict)
         assert result["text"] == "Test response"
-        mock_detailed_sync.assert_called_once_with("test question", 60, None, None)
+        mock_detailed_sync.assert_called_once_with(
+            "test question", 60, None, None, None
+        )
 
     @patch(
         "mcp_coder.llm.providers.claude.claude_code_api.ask_claude_code_api_detailed_sync"
@@ -352,7 +354,7 @@ class TestAskClaudeCodeApi:
         # Verify
         assert result["text"] == "Response with env"
         mock_detailed_sync.assert_called_once_with(
-            "test question", 30.0, None, env_vars
+            "test question", 30.0, None, env_vars, None
         )
 
 
@@ -501,7 +503,7 @@ class TestAskClaudeCodeApiDetailed:
 
         # Verify
         assert result["text"] == "Response"
-        mock_create_client.assert_called_once_with(None, env=env_vars)
+        mock_create_client.assert_called_once_with(None, env=env_vars, cwd=None)
 
 
 @pytest.mark.claude_api_integration

--- a/tests/llm/providers/claude/test_claude_code_interface.py
+++ b/tests/llm/providers/claude/test_claude_code_interface.py
@@ -28,7 +28,7 @@ class TestAskClaudeCodeSessionSupport:
 
         assert response == "CLI response"
         mock_cli.assert_called_once_with(
-            "Test", session_id="cli-session-123", timeout=30, env_vars=None
+            "Test", session_id="cli-session-123", timeout=30, env_vars=None, cwd=None
         )
 
     @patch("mcp_coder.llm.providers.claude.claude_code_interface.ask_claude_code_api")
@@ -48,7 +48,7 @@ class TestAskClaudeCodeSessionSupport:
 
         assert response == "API response"
         mock_api.assert_called_once_with(
-            "Test", session_id="api-session-456", timeout=30, env_vars=None
+            "Test", session_id="api-session-456", timeout=30, env_vars=None, cwd=None
         )
 
     @patch("mcp_coder.llm.providers.claude.claude_code_interface.ask_claude_code_cli")
@@ -104,7 +104,7 @@ class TestAskClaudeCodeSessionSupport:
 
         # Should pass None as session_id to underlying function
         mock_cli.assert_called_once_with(
-            "Test", session_id=None, timeout=30, env_vars=None
+            "Test", session_id=None, timeout=30, env_vars=None, cwd=None
         )
         assert response == "Default behavior"
 
@@ -124,7 +124,7 @@ class TestAskClaudeCodeSessionSupport:
         response = ask_claude_code("Test", method="api")
 
         mock_api.assert_called_once_with(
-            "Test", session_id=None, timeout=30, env_vars=None
+            "Test", session_id=None, timeout=30, env_vars=None, cwd=None
         )
         assert response == "API default"
 
@@ -144,7 +144,7 @@ class TestAskClaudeCodeSessionSupport:
         ask_claude_code("Test", method="cli", timeout=60)
 
         mock_cli.assert_called_once_with(
-            "Test", session_id=None, timeout=60, env_vars=None
+            "Test", session_id=None, timeout=60, env_vars=None, cwd=None
         )
 
     @patch("mcp_coder.llm.providers.claude.claude_code_interface.ask_claude_code_cli")
@@ -165,7 +165,7 @@ class TestAskClaudeCodeSessionSupport:
 
         assert response == "CLI response with env vars"
         mock_cli.assert_called_once_with(
-            "Test", session_id=None, timeout=30, env_vars=test_env_vars
+            "Test", session_id=None, timeout=30, env_vars=test_env_vars, cwd=None
         )
 
 

--- a/tests/llm/providers/claude/test_llm_sessions.py
+++ b/tests/llm/providers/claude/test_llm_sessions.py
@@ -104,6 +104,7 @@ class MockClaudeAPI:
         session_id: Optional[str] = None,
         timeout: int = 30,
         env_vars: Optional[Dict[str, str]] = None,
+        cwd: Optional[str] = None,
     ) -> LLMResponseDict:
         """Simulate API call."""
         self.call_count += 1

--- a/tests/llm/test_interface.py
+++ b/tests/llm/test_interface.py
@@ -21,7 +21,12 @@ class TestAskLLM:
         result = ask_llm("Test question", provider="claude", method="cli", timeout=30)
 
         mock_ask_claude_code.assert_called_once_with(
-            "Test question", method="cli", session_id=None, timeout=30, env_vars=None
+            "Test question",
+            method="cli",
+            session_id=None,
+            timeout=30,
+            env_vars=None,
+            cwd=None,
         )
         assert result == "Test response from Claude"
 
@@ -33,7 +38,12 @@ class TestAskLLM:
         result = ask_llm("Test question")
 
         mock_ask_claude_code.assert_called_once_with(
-            "Test question", method="cli", session_id=None, timeout=30, env_vars=None
+            "Test question",
+            method="cli",
+            session_id=None,
+            timeout=30,
+            env_vars=None,
+            cwd=None,
         )
         assert result == "Default response"
 
@@ -60,7 +70,12 @@ class TestAskLLM:
         result = ask_llm("Test question", timeout=60)
 
         mock_ask_claude_code.assert_called_once_with(
-            "Test question", method="cli", session_id=None, timeout=60, env_vars=None
+            "Test question",
+            method="cli",
+            session_id=None,
+            timeout=60,
+            env_vars=None,
+            cwd=None,
         )
         assert result == "Timeout response"
 
@@ -74,7 +89,12 @@ class TestAskLLM:
         )  # Even though not implemented yet
 
         mock_ask_claude_code.assert_called_once_with(
-            "Test question", method="api", session_id=None, timeout=30, env_vars=None
+            "Test question",
+            method="api",
+            session_id=None,
+            timeout=30,
+            env_vars=None,
+            cwd=None,
         )
         assert result == "Method response"
 
@@ -96,6 +116,7 @@ class TestAskLLM:
             session_id="test-session-123",
             timeout=30,
             env_vars=None,
+            cwd=None,
         )
         assert result == "Response with session"
 
@@ -108,7 +129,12 @@ class TestAskLLM:
         result = ask_llm("Test question")
 
         mock_ask_claude_code.assert_called_once_with(
-            "Test question", method="cli", session_id=None, timeout=30, env_vars=None
+            "Test question",
+            method="cli",
+            session_id=None,
+            timeout=30,
+            env_vars=None,
+            cwd=None,
         )
         assert result == "Response without session"
 
@@ -127,6 +153,7 @@ class TestAskLLM:
             session_id="api-session-456",
             timeout=30,
             env_vars=None,
+            cwd=None,
         )
         assert result == "API response with session"
 
@@ -160,6 +187,7 @@ class TestAskLLM:
             session_id=None,
             timeout=30,
             env_vars=test_env_vars,
+            cwd=None,
         )
         assert result == "Response with env vars"
 
@@ -181,7 +209,7 @@ class TestAskClaudeCode:
         result = ask_claude_code("Test question", method="cli", timeout=30)
 
         mock_ask_claude_code_cli.assert_called_once_with(
-            "Test question", session_id=None, timeout=30, env_vars=None
+            "Test question", session_id=None, timeout=30, env_vars=None, cwd=None
         )
         assert result == "CLI response"
 
@@ -199,7 +227,7 @@ class TestAskClaudeCode:
         result = ask_claude_code("Test question")
 
         mock_ask_claude_code_cli.assert_called_once_with(
-            "Test question", session_id=None, timeout=30, env_vars=None
+            "Test question", session_id=None, timeout=30, env_vars=None, cwd=None
         )
         assert result == "Default CLI response"
 
@@ -217,7 +245,7 @@ class TestAskClaudeCode:
         result = ask_claude_code("Test question", method="api", timeout=30)
 
         mock_ask_claude_code_api.assert_called_once_with(
-            "Test question", session_id=None, timeout=30, env_vars=None
+            "Test question", session_id=None, timeout=30, env_vars=None, cwd=None
         )
         assert result == "API response"
 
@@ -250,7 +278,7 @@ class TestAskClaudeCode:
         result = ask_claude_code("Test question", timeout=45)
 
         mock_ask_claude_code_cli.assert_called_once_with(
-            "Test question", session_id=None, timeout=45, env_vars=None
+            "Test question", session_id=None, timeout=45, env_vars=None, cwd=None
         )
         assert result == "Custom timeout response"
 
@@ -272,7 +300,11 @@ class TestIntegration:
         )
 
         mock_ask_claude_code_cli.assert_called_once_with(
-            "Integration test question", session_id=None, timeout=25, env_vars=None
+            "Integration test question",
+            session_id=None,
+            timeout=25,
+            env_vars=None,
+            cwd=None,
         )
         assert result == "Full chain response"
 
@@ -310,6 +342,7 @@ class TestIntegration:
             session_id="integration-session-789",
             timeout=25,
             env_vars=None,
+            cwd=None,
         )
         assert result == "Full chain response with session"
 
@@ -341,7 +374,7 @@ class TestPromptLLM:
         result = prompt_llm("Test question", method="cli")
 
         mock_ask_claude_code_cli.assert_called_once_with(
-            "Test question", session_id=None, timeout=30, env_vars=None
+            "Test question", session_id=None, timeout=30, env_vars=None, cwd=None
         )
         assert isinstance(result, dict)
         assert result["version"] == "1.0"
@@ -369,7 +402,7 @@ class TestPromptLLM:
         result = prompt_llm("Test question", method="api")
 
         mock_ask_claude_code_api.assert_called_once_with(
-            "Test question", session_id=None, timeout=30, env_vars=None
+            "Test question", session_id=None, timeout=30, env_vars=None, cwd=None
         )
         assert isinstance(result, dict)
         assert result["method"] == "api"
@@ -394,7 +427,11 @@ class TestPromptLLM:
         result = prompt_llm("Follow up", method="cli", session_id="existing-session")
 
         mock_ask_claude_code_cli.assert_called_once_with(
-            "Follow up", session_id="existing-session", timeout=30, env_vars=None
+            "Follow up",
+            session_id="existing-session",
+            timeout=30,
+            env_vars=None,
+            cwd=None,
         )
         assert result["session_id"] == "existing-session"
 
@@ -417,7 +454,7 @@ class TestPromptLLM:
         result = prompt_llm("Follow up", method="api", session_id="api-session")
 
         mock_ask_claude_code_api.assert_called_once_with(
-            "Follow up", session_id="api-session", timeout=30, env_vars=None
+            "Follow up", session_id="api-session", timeout=30, env_vars=None, cwd=None
         )
         assert result["session_id"] == "api-session"
 
@@ -495,7 +532,7 @@ class TestPromptLLM:
         result = prompt_llm("Test", timeout=60)
 
         mock_ask_claude_code_cli.assert_called_once_with(
-            "Test", session_id=None, timeout=60, env_vars=None
+            "Test", session_id=None, timeout=60, env_vars=None, cwd=None
         )
         assert result["text"] == "Response with custom timeout"
 
@@ -518,7 +555,7 @@ class TestPromptLLM:
         result = prompt_llm("Test question")
 
         mock_ask_claude_code_cli.assert_called_once_with(
-            "Test question", session_id=None, timeout=30, env_vars=None
+            "Test question", session_id=None, timeout=30, env_vars=None, cwd=None
         )
         assert result["provider"] == "claude"
         assert result["method"] == "cli"
@@ -543,7 +580,11 @@ class TestPromptLLM:
         result = prompt_llm("Test question", method="cli", env_vars=test_env_vars)
 
         mock_ask_claude_code_cli.assert_called_once_with(
-            "Test question", session_id=None, timeout=30, env_vars=test_env_vars
+            "Test question",
+            session_id=None,
+            timeout=30,
+            env_vars=test_env_vars,
+            cwd=None,
         )
         assert result["text"] == "CLI response with env vars"
 
@@ -567,6 +608,10 @@ class TestPromptLLM:
         result = prompt_llm("Test question", method="api", env_vars=test_env_vars)
 
         mock_ask_claude_code_api.assert_called_once_with(
-            "Test question", session_id=None, timeout=30, env_vars=test_env_vars
+            "Test question",
+            session_id=None,
+            timeout=30,
+            env_vars=test_env_vars,
+            cwd=None,
         )
         assert result["text"] == "API response with env vars"

--- a/tests/workflows/implement/test_task_processing.py
+++ b/tests/workflows/implement/test_task_processing.py
@@ -605,8 +605,10 @@ class TestIntegration:
     )
     @patch("mcp_coder.workflows.implement.task_processing.get_prompt")
     @patch("mcp_coder.workflows.implement.task_processing.get_next_task")
+    @patch("mcp_coder.workflows.implement.task_processing.prepare_llm_environment")
     def test_full_task_processing_workflow(
         self,
+        mock_prepare_env: MagicMock,
         mock_get_next_task: MagicMock,
         mock_get_prompt: MagicMock,
         mock_llm_call: MagicMock,
@@ -622,6 +624,10 @@ class TestIntegration:
         llm_method = "claude_code_api"
 
         # Setup successful workflow
+        mock_prepare_env.return_value = {
+            "MCP_CODER_PROJECT_DIR": "C:\\test\\project",
+            "MCP_CODER_VENV_DIR": "C:\\Users\\Marcus\\Documents\\GitHub\\mcp_coder\\.venv",
+        }
         mock_get_next_task.return_value = "Step 2: Implement feature X"
         mock_get_prompt.return_value = "Implementation Prompt: [task_info]"
         mock_llm_call.return_value = (
@@ -660,7 +666,7 @@ Current task from TASK_TRACKER.md: Step 2: Implement feature X
 
 Please implement this task step by step."""
         mock_llm_call.assert_called_once_with(
-            expected_prompt, "claude", "api", timeout=1800, env_vars=ANY
+            expected_prompt, "claude", "api", timeout=1800, env_vars=ANY, cwd=ANY
         )
 
         # Verify conversation saved with comprehensive data


### PR DESCRIPTION
## Summary
Ensures Claude Code subprocess executes in the correct project directory by passing `project_dir` (or `cwd`) parameter through all LLM interface layers.

## Changes
- Add `project_dir` parameter to `ask_llm()` and `prompt_llm()` in interface.py
- Add `cwd` parameter to Claude Code API functions (SDK client, async/sync wrappers)
- Add `cwd` parameter to Claude Code CLI wrapper
- Pass `project_dir` through all command handlers (prompt, commit, implement workflows)
- Update all tests to expect new `project_dir`/`cwd` parameter in function calls
- Set working directory in ClaudeCodeOptions for API method
- Set working directory via subprocess `cwd` parameter for CLI method