### PR TITLE
fix: support GitHub URLs with embedded credentials

### DIFF
--- a/src/mcp_coder/utils/github_operations/github_utils.py
+++ b/src/mcp_coder/utils/github_operations/github_utils.py
@@ -13,6 +13,8 @@ def parse_github_url(url: str) -> Optional[Tuple[str, str]]:
     Supports multiple GitHub URL formats:
     - HTTPS: https://github.com/owner/repo
     - HTTPS with .git: https://github.com/owner/repo.git
+    - HTTPS with credentials: https://token@github.com/owner/repo.git
+    - HTTPS with user:pass: https://user:pass@github.com/owner/repo.git
     - SSH: git@github.com:owner/repo.git
     - Short format: owner/repo
 
@@ -24,6 +26,8 @@ def parse_github_url(url: str) -> Optional[Tuple[str, str]]:
 
     Examples:
         >>> parse_github_url("https://github.com/user/repo")
+        ('user', 'repo')
+        >>> parse_github_url("https://token@github.com/user/repo.git")
         ('user', 'repo')
         >>> parse_github_url("git@github.com:user/repo.git")
         ('user', 'repo')
@@ -37,11 +41,11 @@ def parse_github_url(url: str) -> Optional[Tuple[str, str]]:
 
     # Pattern to match GitHub URLs in various formats
     # HTTPS: https://github.com/owner/repo(.git)?
+    # HTTPS with credentials: https://[user[:pass]@]github.com/owner/repo(.git)?
     # SSH: git@github.com:owner/repo(.git)?
     # Short: owner/repo
-    github_pattern = (
-        r"(?:https://github\.com/|git@github\.com:|^)([^/]+)/([^/\.]+)(?:\.git)?/?$"
-    )
+    # The (?:[^@]+@)? part matches optional credentials (anything before @)
+    github_pattern = r"(?:https://(?:[^@]+@)?github\.com/|git@github\.com:|^)([^/]+)/([^/\.]+)(?:\.git)?/?$"
     match = re.match(github_pattern, url.strip())
 
     if not match:

--- a/tests/utils/github_operations/test_github_utils.py
+++ b/tests/utils/github_operations/test_github_utils.py
@@ -109,6 +109,33 @@ class TestGitHubUtils:
         result = parse_github_url("user/repo")
         assert result == ("user", "repo")
 
+    def test_parse_github_url_https_with_token(self) -> None:
+        """Test parsing HTTPS URLs with token as username."""
+        result = parse_github_url("https://token@github.com/user/repo.git")
+        assert result == ("user", "repo")
+
+    def test_parse_github_url_https_with_username(self) -> None:
+        """Test parsing HTTPS URLs with username only."""
+        result = parse_github_url("https://username@github.com/user/repo")
+        assert result == ("user", "repo")
+
+    def test_parse_github_url_https_with_username_password(self) -> None:
+        """Test parsing HTTPS URLs with username and password."""
+        result = parse_github_url("https://username:password@github.com/user/repo.git")
+        assert result == ("user", "repo")
+
+    def test_parse_github_url_https_with_special_chars_in_credentials(self) -> None:
+        """Test parsing HTTPS URLs with special characters in credentials."""
+        # Test with asterisks (like the actual error case)
+        result = parse_github_url(
+            "https://****@github.com/MarcusJellinghaus/mcp_coder.git"
+        )
+        assert result == ("MarcusJellinghaus", "mcp_coder")
+
+        # Test with complex token-like string
+        result = parse_github_url("https://ghp_abc123xyz789@github.com/owner/repo.git")
+        assert result == ("owner", "repo")
+
     def test_parse_github_url_invalid(self) -> None:
         """Test parsing invalid URLs returns None."""
         assert parse_github_url("invalid-url") is None


### PR DESCRIPTION
## Summary
Enhances GitHub URL parser to handle HTTPS URLs with embedded authentication credentials (tokens, username:password).

## Changes
- Update regex pattern to match credentials in GitHub URLs
- Add support for token@github.com format
- Add support for user:pass@github.com format
- Add comprehensive test cases for credential variations
- Update docstring with credential format examples