### PR TITLE
docs: add GitHub label workflow setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ mypy src/
 
 - [Development Process](pr_info/DEVELOPMENT_PROCESS.md) - Detailed methodology
 - [Project Vision](project_idea.md) - Comprehensive project overview
+- [Label Workflow Setup](docs/configuration/LABEL_WORKFLOW_SETUP.md) - GitHub Actions for auto-labeling issues
 
 ## 🔗 Related Projects
 

--- a/docs/configuration/CONFIG.md
+++ b/docs/configuration/CONFIG.md
@@ -385,3 +385,4 @@ docker run -v ~/.config/mcp_coder:/root/.config/mcp_coder my-container
 
 - [README.md](../../README.md) - Installation and quick start
 - [ARCHITECTURE.md](../architecture/ARCHITECTURE.md) - System architecture
+- [LABEL_WORKFLOW_SETUP.md](LABEL_WORKFLOW_SETUP.md) - GitHub Actions for issue labels

--- a/docs/configuration/LABEL_WORKFLOW_SETUP.md
+++ b/docs/configuration/LABEL_WORKFLOW_SETUP.md
@@ -1,0 +1,133 @@
+# GitHub Label Workflow Setup
+
+## Why
+
+The mcp-coder development workflow tracks issues through status labels (`status-01:created` → `status-10:pr-created`). New issues must start with `status-01:created` so that:
+
+- Issues are visible in the workflow pipeline
+- The `/approve` command can transition them to the next status
+- No issues get lost without a status label
+
+This setup auto-labels new issues with `status-01:created` using a GitHub Action.
+
+## Setup Steps
+
+### 1. Create the GitHub Actions
+
+Copy both workflow files to `.github/workflows/` in your repository.
+
+**`label-new-issues.yml`** - Auto-labels new issues:
+
+```yaml
+name: Label New Issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add status label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['status-01:created']
+            });
+```
+
+**`approve-command.yml`** - Handles `/approve` comments to promote issues:
+
+```yaml
+name: Approve Command
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  handle-approve:
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request == null && contains(github.event.comment.body, '/approve')
+    permissions:
+      issues: write
+    steps:
+      - name: Handle approve command
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comment = context.payload.comment.body.trim();
+            if (comment !== '/approve') return;
+            
+            const issue = context.payload.issue;
+            const labels = issue.labels.map(l => l.name);
+            
+            const promotions = {
+              'status-01:created': 'status-02:awaiting-planning',
+              'status-04:plan-review': 'status-05:plan-ready',
+              'status-07:code-review': 'status-08:ready-pr'
+            };
+            
+            for (const [currentStatus, nextStatus] of Object.entries(promotions)) {
+              if (labels.includes(currentStatus)) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  name: currentStatus
+                }).catch(() => {});
+                
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  labels: [nextStatus]
+                });
+                
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `✅ Status promoted: \`${currentStatus}\` → \`${nextStatus}\``
+                });
+                return;
+              }
+            }
+            
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: `⚠️ Cannot promote. Issue needs status: \`status-01:created\`, \`status-04:plan-review\`, or \`status-07:code-review\``
+            });
+```
+
+### 2. Create Workflow Labels
+
+Run from your project directory:
+
+```bash
+python workflows/define_labels.py
+```
+
+This creates all workflow status labels (`status-01:created` through `status-10:pr-created`) in your GitHub repository.
+
+Use `--dry-run` to preview changes first.
+
+### 3. Verify
+
+Create a test issue - it should automatically receive the `status-01:created` label.
+
+## Prerequisites
+
+- GitHub Actions enabled on repository
+- GitHub token configured in config file (for `define_labels.py`):
+  - Linux/macOS: `~/.mcp_coder/config.toml`
+  - Windows: `%USERPROFILE%\.mcp_coder\config.toml`

--- a/pr_info/DEVELOPMENT_PROCESS.md
+++ b/pr_info/DEVELOPMENT_PROCESS.md
@@ -126,6 +126,8 @@ flowchart TD
 - **LLM Assistant** - Generates code, plans, documentation via structured prompts
 - **Automated Tools** - Quality checks (pylint, mypy, pytest), formatting, git operations
 
+**📋 Prerequisites:** Set up GitHub Actions for auto-labeling and `/approve` command. See [Label Workflow Setup](../docs/configuration/LABEL_WORKFLOW_SETUP.md).
+
 ---
 
 ## Detailed Workflows


### PR DESCRIPTION
## Summary
Adds documentation for setting up GitHub Actions that auto-label new issues and handle the `/approve` command for status transitions in the mcp-coder workflow.

## Changes
- Add new LABEL_WORKFLOW_SETUP.md guide with GitHub Actions YAML examples
- Add cross-references to label setup docs in README.md, CONFIG.md, and DEVELOPMENT_PROCESS.md
- Document the label-new-issues.yml workflow for auto-labeling
- Document the approve-command.yml workflow for status promotions