### PR TITLE
fix: ignore uv.lock in task tracker update validation

### DIFF
--- a/src/mcp_coder/workflows/implement/core.py
+++ b/src/mcp_coder/workflows/implement/core.py
@@ -8,7 +8,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-from mcp_coder.constants import PROMPTS_FILE_PATH
+from mcp_coder.constants import DEFAULT_IGNORED_BUILD_ARTIFACTS, PROMPTS_FILE_PATH
 from mcp_coder.llm.env import prepare_llm_environment
 from mcp_coder.llm.interface import ask_llm
 from mcp_coder.prompt_manager import get_prompt
@@ -112,6 +112,11 @@ def prepare_task_tracker(
 
         # Only staged and modified files should contain TASK_TRACKER.md
         all_changed = status["staged"] + status["modified"] + status["untracked"]
+
+        # Filter out auto-generated build artifacts (e.g., uv.lock)
+        ignore_set = set(DEFAULT_IGNORED_BUILD_ARTIFACTS)
+        all_changed = [f for f in all_changed if f not in ignore_set]
+
         task_tracker_file = f"{PR_INFO_DIR}/TASK_TRACKER.md"
 
         # Check if only TASK_TRACKER.md was modified (case-insensitive comparison)


### PR DESCRIPTION
## Summary

- Filter out `uv.lock` from changed files validation in `prepare_task_tracker`
- Use existing `DEFAULT_IGNORED_BUILD_ARTIFACTS` constant for consistency with rest of codebase
- Add unit test to verify uv.lock is properly ignored

## Problem

When running `mcp-coder implement` on Windows/Jenkins, the task tracker update was failing with:
```
ERROR - Unexpected files were modified during task tracker update:
ERROR -   Expected: [pr_info/TASK_TRACKER.md]
ERROR -   Found: ['pr_info/TASK_TRACKER.md', 'uv.lock']
```

This happens because `uv` automatically updates `uv.lock` during MCP server initialization.

## Solution

The `prepare_task_tracker` function now filters out files listed in `DEFAULT_IGNORED_BUILD_ARTIFACTS` (which includes `uv.lock`) when checking for unexpected file changes. This is consistent with how `is_working_directory_clean` handles ignored files elsewhere in the codebase.

## Test plan

- [x] Added `test_prepare_task_tracker_ignores_uv_lock` unit test
- [x] Verified test fails without the fix (TDD)
- [x] Verified test passes with the fix
- [x] All existing tests pass