### PR TITLE
fix: prevent Windows Git Bash path conversion in issue_approve command

### DIFF
--- a/.claude/commands/issue_approve.md
+++ b/.claude/commands/issue_approve.md
@@ -14,9 +14,9 @@ Approve the current issue to transition it to the next status in the workflow.
    - Requirements are clear
    - No blocking questions remain
 
-3. Comment `/approve` on the issue:
+3. Comment `/approve` on the issue (use MSYS_NO_PATHCONV to prevent Windows Git Bash path conversion):
 ```bash
-gh issue comment <issue_number> --body "/approve"
+MSYS_NO_PATHCONV=1 gh issue comment <issue_number> --body "/approve"
 ```
 
 This triggers the GitHub Action to promote the issue status (e.g., `status-01:created` → `status-02:awaiting-planning`).


### PR DESCRIPTION
## Summary

- Fix Windows Git Bash path conversion issue in `/issue_approve` slash command

## Problem

On Windows with Git Bash, the command `gh issue comment --body "/approve"` was being converted to `gh issue comment --body "C:/Program Files/Git/approve"` due to MSYS path conversion.

## Solution

Add `MSYS_NO_PATHCONV=1` environment variable prefix to disable path conversion for that specific command.

## Test plan

- [x] Verified fix works on Windows Git Bash
- [x] Posted correct `/approve` comment on issue #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)