### PR TITLE
fix: add MSYS_NO_PATHCONV bash permission to issue_approve command

### DIFF
--- a/.claude/commands/issue_approve.md
+++ b/.claude/commands/issue_approve.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(gh issue comment:*), Read
+allowed-tools: Bash(gh issue comment:*), Read, Bash(MSYS_NO_PATHCONV=1 gh issue comment:*)
 workflow-stage: issue-discussion
 suggested-next: (bot runs create_plan) -> /clear -> plan_review
 ---
@@ -9,6 +9,7 @@ suggested-next: (bot runs create_plan) -> /clear -> plan_review
 Approve the current issue to transition it to the next status in the workflow.
 
 **Instructions:**
+
 1. If no issue context is found from prior `/issue_analyse` or `/issue_create`, respond: "No issue context found. Please run `/issue_analyse <number>` or `/issue_create` first."
 
 2. Validate that the issue is ready for approval:
@@ -17,6 +18,7 @@ Approve the current issue to transition it to the next status in the workflow.
    - No blocking questions remain
 
 3. Comment `/approve` on the issue (use MSYS_NO_PATHCONV to prevent Windows Git Bash path conversion):
+
 ```bash
 MSYS_NO_PATHCONV=1 gh issue comment <issue_number> --body "/approve"
 ```


### PR DESCRIPTION
## Summary

- Add `Bash(MSYS_NO_PATHCONV=1 gh issue comment:*)` to allowed-tools in issue_approve command
- Improved markdown formatting with blank lines before code blocks

## Context

The `MSYS_NO_PATHCONV` environment variable is needed on Windows Git Bash to prevent path conversion of the `/approve` argument. Without this permission, the command would fail.

## Test plan

- [ ] Verify `/issue_approve` command works on Windows with the MSYS workaround