### PR TITLE
fix(logging): include user prompts in stream-json session logs

### DIFF
--- a/tests/llm/providers/claude/test_claude_cli_wrappers.py
+++ b/tests/llm/providers/claude/test_claude_cli_wrappers.py
@@ -87,9 +87,11 @@ class TestIOWrappers:
             assert "--resume" in command
             assert "existing" in command
             assert result["session_id"] == "existing"
-            # Verify stdin was used
+            # Verify stdin was used with JSON-formatted input
             options = call_args[0][1]
-            assert options.input_data == "Follow up"
+            input_data = json.loads(options.input_data)
+            assert input_data["type"] == "user"
+            assert input_data["message"]["content"] == "Follow up"
 
 
 class TestCliLogging:

--- a/tests/llm/providers/claude/test_claude_mcp_config.py
+++ b/tests/llm/providers/claude/test_claude_mcp_config.py
@@ -24,7 +24,7 @@ class TestClaudeMcpConfig:
         """Verify command built correctly without mcp_config parameter."""
         cmd = build_cli_command(session_id=None, claude_cmd="claude")
 
-        # Expected command structure without mcp_config (uses stream-json by default)
+        # Expected command structure without mcp_config (uses stream-json with full logging)
         assert cmd == [
             "claude",
             "-p",
@@ -32,6 +32,9 @@ class TestClaudeMcpConfig:
             "--output-format",
             "stream-json",
             "--verbose",
+            "--input-format",
+            "stream-json",
+            "--replay-user-messages",
         ]
         assert "--mcp-config" not in cmd
         assert "--strict-mcp-config" not in cmd


### PR DESCRIPTION
## Summary

- Enable complete conversation logging by using Claude CLI's `--input-format stream-json` and `--replay-user-messages` flags
- Add `format_stream_json_input()` function to format prompts as JSON for stream-json input
- Session logs now capture user prompts, tool calls, assistant responses, and cost statistics

## Test plan

- [x] Run unit tests: `pytest tests/llm/providers/claude/test_claude_code_cli.py -v`
- [x] Run all Claude provider tests: `pytest tests/llm/providers/claude/ -v`
- [x] Verify pylint passes
- [x] Verify mypy passes
- [x] Manual test: Run a Claude CLI command and verify user prompt appears in NDJSON log

🤖 Generated with [Claude Code](https://claude.com/claude-code)