### PR TITLE
Simplify /issue_update by removing original issue preservation

### DIFF
--- a/.claude/commands/issue_update.md
+++ b/.claude/commands/issue_update.md
@@ -19,8 +19,6 @@ gh issue view <issue_number> --json title,body
 3. Draft updated issue text with:
    - Clear, concise title
    - Well-structured body with implementation ideas
-   - Preserve the original issue content at the bottom under:
-     `# Original issue: [old title]\n[old body]`
 
 4. Write the issue body to a temp file (avoids bash escaping issues with markdown):
 ```python
@@ -48,4 +46,3 @@ The base branch must be a single line. Multiple lines will cause an error during
 - Summary of the requirement
 - Discussed implementation approach (concise)
 - Any constraints or considerations identified
-- Original issue content preserved


### PR DESCRIPTION
## Summary
- Removed requirement to preserve original issue content in `/issue_update` command
- Simplifies updated issues by removing redundant "Original Issue" section
- Makes issue updates cleaner and less confusing

## Changes
- Removed instruction to append original issue under `# Original issue:` heading
- Removed checklist item about preserving original content
- Updated `/issue_update` command documentation in `.claude/commands/issue_update.md`

## Test plan
- [ ] Verify `/issue_update` command still functions correctly with real issue
- [ ] Confirm updated issues are cleaner without duplicate content
- [ ] Test workflow: `/issue_analyse` → `/issue_update` → `/issue_approve`

Resolves #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)