### PR TITLE
fix(gitignore): consolidate .mcp-coder entries into single wildcard pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,16 +36,18 @@ dist/
 .mcp.macos.json
 checks_output.txt
 bash.exe.stackdump
-/.mcp-coder/responses
 /.mcp-coder-tmp/
 *.isorted
+
+# Log folder for LLM sessions etc
+/.mcp-coder/*
+
 
 # profiler data
 docs/tests/performance_data/prof/*.prof
 
 # Generated dependency reports (regenerate with: tach report)
 docs/architecture/dependencies/dependency_report.html
-/.mcp-coder/create_plan_sessions
 
 # Lock files (regenerate with: uv sync)
 uv.lock


### PR DESCRIPTION
## Summary
- Replaces individual `/.mcp-coder/responses` and `/.mcp-coder/create_plan_sessions` entries with a single `/.mcp-coder/*` wildcard rule
- Adds a comment clarifying the purpose of the ignore rule (log folder for LLM sessions)

## Test plan
- [ ] Verify `.mcp-coder/` directory contents are ignored by git after this change