### PR TITLE
fix(vscodeclaude): show current GitHub status when stale, fix window title false positive

### DIFF
--- a/src/mcp_coder/workflows/vscodeclaude/sessions.py
+++ b/src/mcp_coder/workflows/vscodeclaude/sessions.py
@@ -298,11 +298,15 @@ def is_vscode_window_open_for_folder(
     # This prevents matching the main repo window ("repo - Visual Studio Code")
     if issue_number is not None and repo:
         repo_name = repo.split("/")[-1].lower() if "/" in repo else repo.lower()
-        issue_pattern = f"#{issue_number}"
+        # Require "[#N" bracket prefix to match vscodeclaude workspace title format:
+        # "[#N stage_short] title - repo_name"
+        # This avoids false positives from GitHub extension or other tools
+        # that may show issue numbers without the bracket (e.g. "#458 - mcp_coder")
+        issue_pattern = f"[#{issue_number}"
 
         for title in titles:
             title_lower = title.lower()
-            # Both issue number AND repo name must be present
+            # Both issue number (with bracket) AND repo name must be present
             if issue_pattern in title and repo_name in title_lower:
                 logger.debug(
                     "Found VSCode window for issue #%d (%s): %s",

--- a/src/mcp_coder/workflows/vscodeclaude/status.py
+++ b/src/mcp_coder/workflows/vscodeclaude/status.py
@@ -319,16 +319,14 @@ def display_status_table(
             get_folder_git_status(folder_path) if folder_path.exists() else "Missing"
         )
 
-        # Get current status for eligibility check
+        # Get current status for eligibility check and stale display
         # Use cached status if available, fall back to session status
+        current_status: str | None = None
         if repo_cached_issues is not None:
             current_status, _ = get_issue_current_status(
                 session["issue_number"], cached_issues=repo_cached_issues
             )
-            status_for_eligibility = current_status or session["status"]
-        else:
-            # No cache available - use session's recorded status
-            status_for_eligibility = session["status"]
+        status_for_eligibility = current_status or session["status"]
         is_eligible = is_status_eligible_for_session(status_for_eligibility)
 
         # Compute is_stale: closed OR ineligible OR status changed
@@ -343,8 +341,9 @@ def display_status_table(
         action = get_next_action(stale, is_dirty, is_running)
 
         # Show status change indicator (but not for closed issues which already have prefix)
+        # Show current (new) status when stale, not the stored (old) status
         if stale and not is_closed:
-            status = f"-> {status}"
+            status = f"-> {current_status or status}"
 
         # Add row to table
         rows.append(

--- a/tests/workflows/vscodeclaude/test_sessions.py
+++ b/tests/workflows/vscodeclaude/test_sessions.py
@@ -802,3 +802,29 @@ class TestWindowTitleMatching:
         )
 
         assert result is False
+
+    def test_does_not_match_title_without_bracket_prefix(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Should NOT match window where issue number appears without [ prefix.
+
+        Regression test: GitHub extension can show e.g. '#219 - mcp_coder' in
+        the window title when browsing an issue, which should NOT be treated as
+        an active vscodeclaude workspace session.
+        """
+        monkeypatch.setattr(
+            "mcp_coder.workflows.vscodeclaude.sessions._get_vscode_window_titles",
+            lambda: ["#219 Fix the thing - mcp_coder - Visual Studio Code"],
+        )
+        monkeypatch.setattr(
+            "mcp_coder.workflows.vscodeclaude.sessions.HAS_WIN32GUI",
+            True,
+        )
+
+        result = is_vscode_window_open_for_folder(
+            folder_path="/workspace/mcp_coder_219",
+            issue_number=219,
+            repo="owner/mcp_coder",
+        )
+
+        assert result is False


### PR DESCRIPTION
## Summary

- **Status display**: When a session is stale, the Status column now shows the current GitHub status (e.g. `-> status-06:implementing`) instead of the old stored session status (`-> status-04:plan-review`). The current status is read from the issue cache already fetched during the status command.
- **VSCode window false positive**: `is_vscode_window_open_for_folder` now requires the `[#N` bracket prefix when matching window titles. The vscodeclaude workspace template sets titles in `[#N stage] title - repo` format, so this correctly distinguishes active workspace windows from false positives (e.g. the GitHub extension showing issue `#N` in the main repo window title).