### PR TITLE
feat: add GitHub URLs and pattern-based log matching

### DIFF
--- a/src/mcp_coder/checks/branch_status.py
+++ b/src/mcp_coder/checks/branch_status.py
@@ -321,14 +321,13 @@ def get_failed_jobs_summary(
 
 
 def collect_branch_status(
-    project_dir: Path, truncate_logs: bool = False, max_log_lines: int = 300
+    project_dir: Path, max_log_lines: int = 300
 ) -> BranchStatusReport:
     """Collect comprehensive branch status from all sources.
 
     Args:
         project_dir: Path to git repository
-        truncate_logs: Whether to truncate CI logs for LLM consumption
-        max_log_lines: Maximum log lines when truncating
+        max_log_lines: Maximum log lines for CI error details
 
     Returns:
         BranchStatusReport with all collected information

--- a/src/mcp_coder/cli/commands/check_branch_status.py
+++ b/src/mcp_coder/cli/commands/check_branch_status.py
@@ -166,7 +166,7 @@ def execute_check_branch_status(args: argparse.Namespace) -> int:
 
         # Collect branch status
         logger.debug("Collecting branch status information")
-        report = collect_branch_status(project_dir, args.llm_truncate)
+        report = collect_branch_status(project_dir)
 
         # Display status report
         # Use errors='replace' to handle emoji encoding issues on Windows

--- a/tests/checks/test_branch_status.py
+++ b/tests/checks/test_branch_status.py
@@ -539,9 +539,7 @@ def test_collect_branch_status_with_truncation() -> None:
         mock_tasks.return_value = True
         mock_label.return_value = "status-03:implementing"
 
-        result = collect_branch_status(
-            project_dir, truncate_logs=True, max_log_lines=50
-        )
+        result = collect_branch_status(project_dir, max_log_lines=50)
 
         # Verify truncation was passed correctly
         mock_branch.assert_called_once_with(project_dir)

--- a/tests/cli/commands/test_check_branch_status.py
+++ b/tests/cli/commands/test_check_branch_status.py
@@ -106,7 +106,7 @@ class TestExecuteCheckBranchStatus:
 
         assert result == 0
         mock_resolve_dir.assert_called_once_with("/test/project")
-        mock_collect.assert_called_once_with(project_dir, False)
+        mock_collect.assert_called_once_with(project_dir)
 
         # Check output contains human-formatted report
         captured = capsys.readouterr()
@@ -142,7 +142,7 @@ class TestExecuteCheckBranchStatus:
 
         assert result == 0
         mock_resolve_dir.assert_called_once_with("/test/project")
-        mock_collect.assert_called_once_with(project_dir, True)
+        mock_collect.assert_called_once_with(project_dir)
 
         # Check output contains LLM-formatted report
         captured = capsys.readouterr()
@@ -184,7 +184,7 @@ class TestExecuteCheckBranchStatus:
 
         assert result == 0
         mock_resolve_dir.assert_called_once_with("/test/project")
-        mock_collect.assert_called_once_with(project_dir, False)
+        mock_collect.assert_called_once_with(project_dir)
         mock_run_fixes.assert_called_once_with(
             project_dir,
             failed_ci_report,
@@ -233,7 +233,7 @@ class TestExecuteCheckBranchStatus:
 
         assert result == 1
         mock_resolve_dir.assert_called_once_with("/test/project")
-        mock_collect.assert_called_once_with(project_dir, False)
+        mock_collect.assert_called_once_with(project_dir)
         mock_run_fixes.assert_called_once()
 
     @patch("mcp_coder.cli.commands.check_branch_status.resolve_project_dir")
@@ -322,7 +322,7 @@ class TestExecuteCheckBranchStatus:
 
         assert result == 0
         mock_resolve_dir.assert_called_once_with(None)
-        mock_collect.assert_called_once_with(project_dir, False)
+        mock_collect.assert_called_once_with(project_dir)
 
 
 # Note: CI waiting tests moved to test_check_branch_status_ci_waiting.py


### PR DESCRIPTION
## Summary
Improves CI failure reporting by adding GitHub Actions URLs to error output and replacing exact log filename matching with pattern-based matching that supports both new GitHub format and old format as fallback.

## Changes
- Add `_find_log_content()` helper with pattern-based log matching (`_{job_name}.txt`) and fallback to old `{job_name}/{step_number}_{step_name}.txt` format
- Add GitHub Actions run URL and per-job URLs to CI error details output
- Show `(logs not available locally)` with GitHub URL when logs are missing
- Remove unused `truncate` parameter from `_build_ci_error_details()`
- Add task tracker file for feature implementation steps