### PR TITLE
feat: rename MCP server from code-checker to tools-py

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,9 +17,9 @@
 | Read file | `Read()` | `mcp__workspace__read_file()` |
 | Edit file | `Edit()` | `mcp__workspace__edit_file()` |
 | Write file | `Write()` | `mcp__workspace__save_file()` |
-| Run pytest | `Bash("pytest ...")` | `mcp__code-checker__run_pytest_check()` |
-| Run pylint | `Bash("pylint ...")` | `mcp__code-checker__run_pylint_check()` |
-| Run mypy | `Bash("mypy ...")` | `mcp__code-checker__run_mypy_check()` |
+| Run pytest | `Bash("pytest ...")` | `mcp__tools-py__run_pytest_check()` |
+| Run pylint | `Bash("pylint ...")` | `mcp__tools-py__run_pylint_check()` |
+| Run mypy | `Bash("mypy ...")` | `mcp__tools-py__run_mypy_check()` |
 | Git operations | ✅ `Bash("git ...")` | ✅ `Bash("git ...")` (allowed) |
 
 ## 🔴 CRITICAL: Code Quality Requirements
@@ -27,9 +27,9 @@
 **MANDATORY**: After making ANY code changes (after EACH edit), you MUST run ALL THREE code quality checks using the EXACT MCP tool names below:
 
 ```
-mcp__code-checker__run_pylint_check
-mcp__code-checker__run_pytest_check
-mcp__code-checker__run_mypy_check
+mcp__tools-py__run_pylint_check
+mcp__tools-py__run_pytest_check
+mcp__tools-py__run_mypy_check
 ```
 
 This runs:
@@ -64,14 +64,14 @@ This runs:
 
 ```python
 # RECOMMENDED: Fast unit tests (excludes all integration tests)
-mcp__code-checker__run_pytest_check(extra_args=["-n", "auto", "-m", "not git_integration and not claude_cli_integration and not claude_api_integration and not formatter_integration and not github_integration and not langchain_integration"])
+mcp__tools-py__run_pytest_check(extra_args=["-n", "auto", "-m", "not git_integration and not claude_cli_integration and not claude_api_integration and not formatter_integration and not github_integration and not langchain_integration"])
 
 # All tests including slow integration tests (not recommended for regular development)
-mcp__code-checker__run_pytest_check(extra_args=["-n", "auto"])
+mcp__tools-py__run_pytest_check(extra_args=["-n", "auto"])
 
 # Specific integration tests (only when needed)
-mcp__code-checker__run_pytest_check(extra_args=["-n", "auto"], markers=["git_integration"])
-mcp__code-checker__run_pytest_check(extra_args=["-n", "auto"], markers=["github_integration"])
+mcp__tools-py__run_pytest_check(extra_args=["-n", "auto"], markers=["git_integration"])
+mcp__tools-py__run_pytest_check(extra_args=["-n", "auto"], markers=["github_integration"])
 ```
 
 **Important:** Without the `-m "not ..."` exclusions, pytest runs ALL tests including slow integration tests that require external resources (git repos, network access, API tokens). For regular development, always use the exclusion pattern as shown in the first example above.
@@ -108,7 +108,7 @@ Bash("pytest tests/")
 mcp__workspace__read_file(file_path="src/example.py")
 mcp__workspace__edit_file(file_path="src/example.py", edits=[...])
 mcp__workspace__save_file(file_path="src/new.py", content="...")
-mcp__code-checker__run_pytest_check(extra_args=["-n", "auto"])
+mcp__tools-py__run_pytest_check(extra_args=["-n", "auto"])
 ```
 
 **WHY MCP TOOLS ARE MANDATORY:**

--- a/.claude/commands/rebase.md
+++ b/.claude/commands/rebase.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git status:*), Bash(git log:*), Bash(git branch:*), Bash(git ls-files:*), Bash(git fetch:*), Bash(git rebase:*), Bash(git add:*), Bash(git rm:*), Bash(git commit:*), Bash(git checkout --ours:*), Bash(git remote get-url:*), Bash(git checkout --theirs:*), Bash(git restore:*), Bash(git stash:*), Bash(git push --force-with-lease:*), Bash(git diff:*), Bash(git rev-parse:*), Bash(gh run view:*), Bash(./tools/format_all.sh:*), Bash(gh issue view:*), mcp__code-checker__run_pylint_check, mcp__code-checker__run_pytest_check, mcp__code-checker__run_mypy_check, mcp__workspace__get_reference_projects, mcp__workspace__list_reference_directory, mcp__workspace__read_reference_file, mcp__workspace__list_directory, mcp__workspace__read_file, mcp__workspace__save_file, mcp__workspace__append_file, mcp__workspace__delete_this_file, mcp__workspace__move_file, mcp__workspace__edit_file
+allowed-tools: Bash(git status:*), Bash(git log:*), Bash(git branch:*), Bash(git ls-files:*), Bash(git fetch:*), Bash(git rebase:*), Bash(git add:*), Bash(git rm:*), Bash(git commit:*), Bash(git checkout --ours:*), Bash(git remote get-url:*), Bash(git checkout --theirs:*), Bash(git restore:*), Bash(git stash:*), Bash(git push --force-with-lease:*), Bash(git diff:*), Bash(git rev-parse:*), Bash(gh run view:*), Bash(./tools/format_all.sh:*), Bash(gh issue view:*), mcp__tools-py__run_pylint_check, mcp__tools-py__run_pytest_check, mcp__tools-py__run_mypy_check, mcp__workspace__get_reference_projects, mcp__workspace__list_reference_directory, mcp__workspace__read_reference_file, mcp__workspace__list_directory, mcp__workspace__read_file, mcp__workspace__save_file, mcp__workspace__append_file, mcp__workspace__delete_this_file, mcp__workspace__move_file, mcp__workspace__edit_file
 workflow-stage: utility
 suggested-next: (context-dependent)
 ---
@@ -40,7 +40,7 @@ echo "Rebasing onto: $BASE_BRANCH"
    - Verify no conflict markers remain
    - `git add <file>`
    - `git rebase --continue`
-4. Run code checks: `mcp__code-checker__run_pytest_check`, `mcp__code-checker__run_pylint_check`, `mcp__code-checker__run_mypy_check`
+4. Run code checks: `mcp__tools-py__run_pytest_check`, `mcp__tools-py__run_pylint_check`, `mcp__tools-py__run_mypy_check`
 5. Fix any issues from merge
 6. Report summary and ask for user confirmation
 7. `git push --force-with-lease`

--- a/.claude/commands/rebase_design.md.txt
+++ b/.claude/commands/rebase_design.md.txt
@@ -42,7 +42,7 @@ Bash(git push --force-with-lease:*)
 
 ### 2. General Permissions (not documented here)
 
-Include all permissions from `.claude/settings.local.json`. These provide standard MCP tool access (filesystem, code-checker, etc.) needed for conflict resolution and code quality checks.
+Include all permissions from `.claude/settings.local.json`. These provide standard MCP tool access (filesystem, tools-py, etc.) needed for conflict resolution and code quality checks.
 
 **Maintenance note:** When `.claude/settings.local.json` changes, update the slash command's `allowed-tools` to include the new general permissions.
 

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,9 @@
 {
   "permissions": {
     "allow": [
-      "mcp__code-checker__run_pylint_check",
-      "mcp__code-checker__run_pytest_check",
-      "mcp__code-checker__run_mypy_check",
+      "mcp__tools-py__run_pylint_check",
+      "mcp__tools-py__run_pytest_check",
+      "mcp__tools-py__run_mypy_check",
       "mcp__workspace__get_reference_projects",
       "mcp__workspace__list_reference_directory",
       "mcp__workspace__read_reference_file",
@@ -50,7 +50,7 @@
   },
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [
-    "code-checker",
+    "tools-py",
     "workspace"
   ]
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "code-checker": {
+    "tools-py": {
       "type": "stdio",
       "command": "${MCP_CODER_VENV_DIR}\\Scripts\\mcp-tools-py.exe",
       "args": [

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ MCP Coder implements a structured 3-layer development approach that separates hu
 │ Claude Code interactively               │     │                ▼                       │
 │                                         │     │         ┌─────────────────┐             │
 │                                         │     │         │  MCP Servers    │             │
-│                                         │     │         │ • code-checker  │             │
+│                                         │     │         │ • tools-py      │             │
 │                                         │     │         │ • filesystem    │             │
 │                                         │     │         └─────────────────┘             │
 └─────────────────────────────────────────┘     └─────────────────────────────────────────┘
@@ -66,7 +66,7 @@ flowchart TD
     
     LW["🤖 LLM Work<br/>(MCP-supported)<br/><br/>• Implementation planning<br/>• Implementation (code writing &<br/>  automated testing)<br/> (multiple steps & sessions)<br/>• Pull request generation"]
     
-    MCP["MCP Servers<br/>• code-checker<br/>• filesystem"]
+    MCP["MCP Servers<br/>• tools-py<br/>• filesystem"]
     
     GH["📂 GitHub Foundation<br/>Source code repositories<br/>Issue tracking with status labels"]
     

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -404,7 +404,7 @@ mcp-coder implement --project-dir /path/to/project
 
 ### Quality Gates (Mandatory Pattern)
 - **Always run**: pylint, pytest, mypy after code changes
-- **MCP integration**: Use `mcp__code-checker__*` tools exclusively
+- **MCP integration**: Use `mcp__tools-py__*` tools exclusively
 - **Architecture access**: `mcp_tools_py.py` - Quality check orchestration with direct API access for mcp_coder workflows
 - **Enforcement**: Documented in `CLAUDE.md` as mandatory requirements
 

--- a/docs/configuration/claude-code.md
+++ b/docs/configuration/claude-code.md
@@ -124,7 +124,7 @@ This file configures Claude Code permissions and MCP server settings for your lo
 {
   "permissions": {
     "allow": [
-      "mcp__code-checker__*",
+      "mcp__tools-py__*",
       "mcp__workspace__*",
       "Bash(git diff:*)",
       "Bash(git status:*)",
@@ -135,7 +135,7 @@ This file configures Claude Code permissions and MCP server settings for your lo
   },
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [
-    "code-checker",
+    "tools-py",
     "workspace"
   ]
 }
@@ -151,7 +151,7 @@ This file configures Claude Code permissions and MCP server settings for your lo
 
 **Security considerations:**
 
-- **Allow MCP servers**: Enable `mcp__code-checker__*` and `mcp__workspace__*` for development workflows
+- **Allow MCP servers**: Enable `mcp__tools-py__*` and `mcp__workspace__*` for development workflows
 - **Allow read-only commands**: `Bash(git diff:*)`, `Bash(git status:*)` are safe
 - **Allow formatting tools**: `Bash(./tools/format_all.sh:*)` for code formatting
 - **Restrict dangerous commands**: Do NOT allow unrestricted `Bash(*)` - this could modify files outside the project or execute arbitrary commands
@@ -197,7 +197,7 @@ These are used in `.mcp.json` to configure MCP servers with correct paths:
 ```json
 {
   "mcpServers": {
-    "code-checker": {
+    "tools-py": {
       "type": "stdio",
       "command": "${MCP_CODER_VENV_DIR}\\Scripts\\mcp-tools-py.exe",
       "args": [

--- a/docs/configuration/config.md
+++ b/docs/configuration/config.md
@@ -597,7 +597,7 @@ When using mcp-coder in automated Jenkins workflows, there are two separate Pyth
 
 ### Why Type Stubs Need Separate Installation
 
-The MCP code-checker runs mypy against **project code** using the **project's virtual environment**. For mypy to resolve types correctly, type stub packages (e.g., `types-requests`, `types-pyperclip`) must be installed in the project's `.venv`, not the execution environment.
+The MCP tools-py server runs mypy against **project code** using the **project's virtual environment**. For mypy to resolve types correctly, type stub packages (e.g., `types-requests`, `types-pyperclip`) must be installed in the project's `.venv`, not the execution environment.
 
 The coordinator command templates automatically run `uv sync --extra types` in the project directory before executing mcp-coder commands.
 

--- a/docs/processes-prompts/refactoring-guide.md
+++ b/docs/processes-prompts/refactoring-guide.md
@@ -90,9 +90,9 @@ Run all checks after each move:
 ./tools/tach_check.sh
 
 # Functionality (Claude Code MCP tools)
-mcp__code-checker__run_pytest_check
-mcp__code-checker__run_pylint_check
-mcp__code-checker__run_mypy_check
+mcp__tools-py__run_pytest_check
+mcp__tools-py__run_pylint_check
+mcp__tools-py__run_mypy_check
 ```
 
 ## Common Patterns

--- a/docs/repository-setup.md
+++ b/docs/repository-setup.md
@@ -401,7 +401,7 @@ Slash commands provide structured workflows for common tasks. Copy the commands 
 
 **Model Context Protocol (MCP)** enables Claude Code to use specialized servers for enhanced functionality:
 
-- **code-checker**: Pylint, pytest, mypy integration
+- **tools-py**: Pylint, pytest, mypy integration
 - **filesystem**: Enhanced file operations
 - **Custom servers**: Project-specific tools
 

--- a/tools/check_version.bat
+++ b/tools/check_version.bat
@@ -7,8 +7,10 @@ echo --- Version Control ---
 git --version
 gh --version
 echo.
-echo --- Python ---
-python --version
+echo --- Python Environment ---
+python -c "import sys; print('Python:', sys.version)"
+python -c "import sys; print('Executable:', sys.executable)"
+python -c "import sys, os; print('Environment:', os.path.dirname(sys.executable))"
 pip --version
 echo.
 echo --- Formatting ---


### PR DESCRIPTION
## Summary
- Rename the MCP server from `code-checker` to `tools-py` across all configuration files, documentation, and slash commands
- Update `.mcp.json`, `.claude/settings.local.json`, and all references in docs and CLAUDE.md
- Enhance `check_version.bat` to show Python executable and environment paths

## Test plan
- [ ] Verify MCP server starts correctly with new `tools-py` name
- [ ] Confirm Claude Code recognizes the renamed MCP tools (`mcp__tools-py__*`)
- [ ] Check that all documentation references are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)