### PR TITLE
chore: add requirements-beta.txt for latest MCP packages from GitHub

### DIFF
--- a/requirements-beta.txt
+++ b/requirements-beta.txt
@@ -1,0 +1,9 @@
+# Override PyPI versions of MCP packages with latest from GitHub.
+# PyPI rejects direct URL dependencies in pyproject.toml, so use this file instead.
+#
+# Usage:
+#   pip install mcp-coder[dev]           # install normally from PyPI
+#   pip install -r requirements-beta.txt  # override with latest from GitHub
+#
+mcp-tools-py @ git+https://github.com/MarcusJellinghaus/mcp-tools-py.git@main
+mcp-workspace @ git+https://github.com/MarcusJellinghaus/mcp-workspace.git@main


### PR DESCRIPTION
## Summary
- Adds `requirements-beta.txt` to install `mcp-tools-py` and `mcp-workspace` from their GitHub main branches instead of PyPI
- Useful for testing latest unreleased changes during development
- PyPI rejects direct URL dependencies in `pyproject.toml`, so a separate requirements file is the standard workaround

## Usage
```bash
pip install mcp-coder[dev]
pip install -r requirements-beta.txt
```