### PR TITLE
feat(labels): use plan_review_supervisor for status-04

### DIFF
--- a/src/mcp_coder/config/labels.json
+++ b/src/mcp_coder/config/labels.json
@@ -38,7 +38,7 @@
         "emoji": "📋",
         "display_name": "PLAN REVIEW",
         "stage_short": "plan",
-        "commands": ["/plan_review", "/discuss"]
+        "commands": ["/plan_review_supervisor"]
       }
     },
     {


### PR DESCRIPTION
## Summary
- Replace `/plan_review` with `/plan_review_supervisor` in status-04 plan-review commands
- Remove `/discuss` from status-04 commands (no longer needed)

## Test plan
- [ ] Verify status-04 triggers `/plan_review_supervisor` correctly
- [ ] Confirm `/discuss` is no longer offered at plan-review stage