### PR TITLE
chore: remove Claude Code version pin (#509)

### DIFF
--- a/claude.bat
+++ b/claude.bat
@@ -21,30 +21,13 @@ if "!VIRTUAL_ENV!"=="" (
     )
 )
 
-REM --- Check Claude Code version (pinned to known-good version for Windows stdout capture) ---
-REM See: https://github.com/anthropics/claude-code/issues/18748
-REM See: https://github.com/MarcusJellinghaus/mcp_coder/issues/509
-set "EXPECTED_CC_VER=2.1.40"
-for /f "tokens=1" %%v in ('C:\Users\%USERNAME%\.local\bin\claude.exe --version 2^>nul') do set "CC_VER=%%v"
-if "!CC_VER!"=="" (
-    echo ERROR: Claude Code not found at C:\Users\%USERNAME%\.local\bin\claude.exe
-    exit /b 1
-)
-if not "!CC_VER!"=="!EXPECTED_CC_VER!" (
-    echo WARNING: Claude Code !CC_VER! may have Windows bash output capture issues
-    echo   Expected: !EXPECTED_CC_VER!  Current: !CC_VER!
-    echo   See https://github.com/MarcusJellinghaus/mcp_coder/issues/509
-)
-
 REM Set project directories for MCP servers
 set "MCP_CODER_PROJECT_DIR=%CD%"
 set "MCP_CODER_VENV_DIR=%CD%\.venv"
-set "DISABLE_AUTOUPDATER=1"
 
 REM Start Claude Code
 echo Starting Claude Code with:
 echo VIRTUAL_ENV=!VIRTUAL_ENV!
 echo MCP_CODER_PROJECT_DIR=!MCP_CODER_PROJECT_DIR!
 echo MCP_CODER_VENV_DIR=!MCP_CODER_VENV_DIR!
-echo DISABLE_AUTOUPDATER=!DISABLE_AUTOUPDATER!
 C:\Users\%USERNAME%\.local\bin\claude.exe %*

--- a/claude_local.bat
+++ b/claude_local.bat
@@ -45,30 +45,13 @@ if !errorlevel! neq 0 (
     exit /b 1
 )
 
-REM --- Check Claude Code version (pinned to known-good version for Windows stdout capture) ---
-REM See: https://github.com/anthropics/claude-code/issues/18748
-REM See: https://github.com/MarcusJellinghaus/mcp_coder/issues/509
-set "EXPECTED_CC_VER=2.1.40"
-for /f "tokens=1" %%v in ('C:\Users\%USERNAME%\.local\bin\claude.exe --version 2^>nul') do set "CC_VER=%%v"
-if "!CC_VER!"=="" (
-    echo ERROR: Claude Code not found at C:\Users\%USERNAME%\.local\bin\claude.exe
-    exit /b 1
-)
-if not "!CC_VER!"=="!EXPECTED_CC_VER!" (
-    echo WARNING: Claude Code !CC_VER! may have Windows bash output capture issues
-    echo   Expected: !EXPECTED_CC_VER!  Current: !CC_VER!
-    echo   See https://github.com/MarcusJellinghaus/mcp_coder/issues/509
-)
-
 REM Set project directories for MCP servers
 set "MCP_CODER_PROJECT_DIR=%CD%"
 set "MCP_CODER_VENV_DIR=%CD%\.venv"
-set "DISABLE_AUTOUPDATER=1"
 
 REM Start Claude Code using the local mcp-coder installation
 echo Starting Claude Code with:
 echo VIRTUAL_ENV=!VIRTUAL_ENV!
 echo MCP_CODER_PROJECT_DIR=!MCP_CODER_PROJECT_DIR!
 echo MCP_CODER_VENV_DIR=!MCP_CODER_VENV_DIR!
-echo DISABLE_AUTOUPDATER=!DISABLE_AUTOUPDATER!
 C:\Users\%USERNAME%\.local\bin\claude.exe %*


### PR DESCRIPTION
## Summary
- Remove Claude Code version check/pin (v2.1.40) from `claude.bat` and `claude_local.bat` — upstream Windows stdout bug is fixed
- Remove `DISABLE_AUTOUPDATER=1` — auto-update stability now handled via `autoUpdatesChannel=stable` in global `~/.claude/settings.json`

## Test plan
- [ ] Launch via `claude.bat` — verify no version warning, Claude starts normally
- [ ] Launch via `claude_local.bat` — same
- [ ] Run `mcp-coder prompt "What is 1 + ONE?"` — verify output shows `2`

Closes #509