### PR TITLE
fix(vscodeclaude): retry uv sync on Windows file lock errors

### DIFF
--- a/src/mcp_coder/workflows/vscodeclaude/templates.py
+++ b/src/mcp_coder/workflows/vscodeclaude/templates.py
@@ -73,12 +73,25 @@ if not exist .venv\Scripts\activate.bat (
         exit /b 1
     )
     echo Installing project dependencies...
+    setlocal EnableDelayedExpansion
+    set UV_RETRY=0
+    :retry_uv_sync
     uv sync --extra dev
     if errorlevel 1 (
-        echo ERROR: Failed to install dependencies.
+        set /a UV_RETRY+=1
+        if !UV_RETRY! LSS 3 (
+            echo WARNING: uv sync failed ^(attempt !UV_RETRY! of 3^). Retrying in 5s...
+            echo Common cause: file lock from antivirus or IDE indexing .venv
+            timeout /t 5 /nobreak >nul
+            goto :retry_uv_sync
+        )
+        echo ERROR: Failed to install dependencies after 3 attempts.
+        echo TIP: Close other programs accessing .venv, then run: uv pip install -e ".[dev]"
+        endlocal
         pause
         exit /b 1
     )
+    endlocal
     set VENV_CREATED=1
 ) else (
     set VENV_CREATED=0

--- a/tests/workflows/vscodeclaude/test_templates.py
+++ b/tests/workflows/vscodeclaude/test_templates.py
@@ -31,6 +31,24 @@ def test_venv_section_installs_dev_dependencies() -> None:
     ), "VENV_SECTION_WINDOWS should not use '--extra types' (incomplete dependencies)"
 
 
+def test_venv_section_has_uv_sync_retry_logic() -> None:
+    """Test that VENV_SECTION_WINDOWS retries uv sync on failure.
+
+    Windows file locks (antivirus, IDE indexing) can cause transient
+    'Access is denied' errors during uv sync renames. A retry loop
+    handles this reliably.
+    """
+    assert (
+        "EnableDelayedExpansion" in VENV_SECTION_WINDOWS
+    ), "VENV_SECTION_WINDOWS needs EnableDelayedExpansion for retry counter"
+    assert (
+        "retry_uv_sync" in VENV_SECTION_WINDOWS
+    ), "VENV_SECTION_WINDOWS should have a retry label for uv sync"
+    assert (
+        "UV_RETRY" in VENV_SECTION_WINDOWS
+    ), "VENV_SECTION_WINDOWS should track retry attempts"
+
+
 def test_automated_section_has_llm_method_claude() -> None:
     """Test that AUTOMATED_SECTION_WINDOWS includes --llm-method claude.
 


### PR DESCRIPTION
## Summary
- Add retry loop (3 attempts, 5s delay) around `uv sync --extra dev` in the vscodeclaude startup template
- Handles transient "Access is denied" (OS error 5) failures caused by Windows file locks from antivirus or IDE indexing `.venv`
- Uses `setlocal EnableDelayedExpansion` for proper retry counter in batch script
- Adds test verifying retry logic is present in the template

## Test plan
- [x] All existing template tests pass (6/6)
- [x] New `test_venv_section_has_uv_sync_retry_logic` test passes
- [x] Ruff checks pass
- [ ] Manual: generate a new vscodeclaude session and verify the batch file contains retry logic