### PR TITLE
feat(init): cherry-pick init command onto main (#567)

### DIFF
--- a/src/mcp_coder/cli/commands/__init__.py
+++ b/src/mcp_coder/cli/commands/__init__.py
@@ -7,12 +7,14 @@ from .create_plan import execute_create_plan
 from .create_pr import execute_create_pr
 from .help import execute_help
 from .implement import execute_implement
+from .init import execute_init
 from .prompt import execute_prompt
 from .verify import execute_verify
 
 __all__ = [
     "coordinator",
     "execute_help",
+    "execute_init",
     "execute_verify",
     "execute_prompt",
     "execute_commit_auto",

--- a/src/mcp_coder/cli/commands/help.py
+++ b/src/mcp_coder/cli/commands/help.py
@@ -38,6 +38,7 @@ USAGE:
 
 COMMANDS:
     help                    Show help information
+    init                    Create default configuration file
     verify                  Verify Claude CLI installation and configuration
     prompt <text>           Execute prompt via Claude API with configurable debug output
 

--- a/src/mcp_coder/cli/commands/init.py
+++ b/src/mcp_coder/cli/commands/init.py
@@ -1,0 +1,38 @@
+"""Init command for the MCP Coder CLI."""
+
+import argparse
+import logging
+
+from ...utils.user_config import create_default_config, get_config_file_path
+
+logger = logging.getLogger(__name__)
+
+
+def execute_init(_args: argparse.Namespace) -> int:
+    """Execute init command to create default configuration file.
+
+    Args:
+        _args: Parsed command-line arguments (unused for this command).
+
+    Returns:
+        Exit code (0 for success, 1 for write failure).
+    """
+    logger.info("Executing init command")
+
+    path = get_config_file_path()
+    try:
+        created = create_default_config()
+    except OSError as e:
+        print(f"Error: Failed to write config to {path}: {e}")
+        return 1
+
+    if created:
+        print(f"Created default config at: {path}")
+        print("Please update it with your actual credentials and settings.")
+        print("\nNext steps:")
+        print("  mcp-coder verify          Check your setup")
+        print("  mcp-coder define-labels   Sync workflow labels to your GitHub repo")
+    else:
+        print(f"Config already exists: {path}")
+
+    return 0

--- a/src/mcp_coder/cli/main.py
+++ b/src/mcp_coder/cli/main.py
@@ -22,6 +22,7 @@ from .commands.gh_tool import execute_get_base_branch
 from .commands.git_tool import execute_compact_diff
 from .commands.help import execute_help, get_help_text
 from .commands.implement import execute_implement
+from .commands.init import execute_init
 from .commands.prompt import execute_prompt
 from .commands.set_status import execute_set_status
 from .commands.verify import execute_verify
@@ -81,6 +82,7 @@ def create_parser() -> argparse.ArgumentParser:
 
     # Simple commands without subparsers
     subparsers.add_parser("help", help="Show help information")
+    subparsers.add_parser("init", help="Create default configuration file")
     add_verify_parser(subparsers)
 
     # Add command parsers from parsers module
@@ -261,6 +263,8 @@ def main() -> int:
         # Route to appropriate command handler
         if args.command == "help":
             return execute_help(args)
+        elif args.command == "init":
+            return execute_init(args)
         elif args.command == "verify":
             return execute_verify(args)
         elif args.command == "prompt":

--- a/tests/cli/commands/test_help.py
+++ b/tests/cli/commands/test_help.py
@@ -30,6 +30,8 @@ def test_get_help_text_contains_all_commands() -> None:
     assert "USAGE:" in help_text
     assert "COMMANDS:" in help_text
     assert "help" in help_text
+    assert "init" in help_text
+    assert "Create default configuration file" in help_text
     assert "commit auto" in help_text
     assert "commit clipboard" in help_text
     assert "EXAMPLES:" in help_text

--- a/tests/cli/commands/test_init.py
+++ b/tests/cli/commands/test_init.py
@@ -1,0 +1,106 @@
+"""Tests for init command functionality."""
+
+import argparse
+import tomllib
+from unittest.mock import patch
+
+import pytest
+
+from mcp_coder.cli.commands.init import execute_init
+
+
+class TestInitCommand:
+    """Tests for execute_init command handler."""
+
+    @patch("mcp_coder.cli.commands.init.get_config_file_path")
+    @patch("mcp_coder.cli.commands.init.create_default_config")
+    def test_init_creates_config_success(
+        self,
+        mock_create: object,
+        mock_path: object,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Test successful config creation prints instructions."""
+        mock_create.return_value = True  # type: ignore[attr-defined]
+        mock_path.return_value = "/fake/path/config.toml"  # type: ignore[attr-defined]
+        args = argparse.Namespace(command="init")
+
+        result = execute_init(args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Created default config at:" in captured.out
+        assert "Please update it" in captured.out
+        assert "Next steps:" in captured.out
+        assert "mcp-coder verify" in captured.out
+        assert "mcp-coder define-labels" in captured.out
+
+    @patch("mcp_coder.cli.commands.init.get_config_file_path")
+    @patch("mcp_coder.cli.commands.init.create_default_config")
+    def test_init_config_already_exists(
+        self,
+        mock_create: object,
+        mock_path: object,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Test existing config prints already-exists message."""
+        mock_create.return_value = False  # type: ignore[attr-defined]
+        mock_path.return_value = "/fake/path/config.toml"  # type: ignore[attr-defined]
+        args = argparse.Namespace(command="init")
+
+        result = execute_init(args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Config already exists:" in captured.out
+
+    @patch("mcp_coder.cli.commands.init.get_config_file_path")
+    @patch("mcp_coder.cli.commands.init.create_default_config")
+    def test_init_write_failure(
+        self,
+        mock_create: object,
+        mock_path: object,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Test write failure returns exit code 1 with error message."""
+        mock_create.side_effect = OSError("Permission denied")  # type: ignore[attr-defined]
+        mock_path.return_value = "/fake/path/config.toml"  # type: ignore[attr-defined]
+        args = argparse.Namespace(command="init")
+
+        result = execute_init(args)
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Error: Failed to write config to" in captured.out
+        assert "Permission denied" in captured.out
+
+    def test_init_template_content_valid_toml_with_sections(
+        self,
+        tmp_path: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test that created config is valid TOML with expected sections."""
+        from pathlib import Path
+
+        from mcp_coder.utils.user_config import (
+            create_default_config,
+            get_config_file_path,
+        )
+
+        config_path = Path(str(tmp_path)) / ".mcp_coder" / "config.toml"
+        monkeypatch.setattr(
+            "mcp_coder.utils.user_config.get_config_file_path",
+            lambda: config_path,
+        )
+
+        created = create_default_config()
+
+        assert created is True
+        assert config_path.exists()
+
+        with open(config_path, "rb") as f:
+            data = tomllib.load(f)
+
+        assert "github" in data
+        assert "jenkins" in data
+        assert "coordinator" in data


### PR DESCRIPTION
## Summary

- Cherry-picks commit `43813e3` from branch `509` onto `main`
- PR #567 was accidentally merged into the `509` branch **after** #566 had already merged `509` into `main`, leaving the `init` command stranded

## Original PR

#567 — `feat(init): add mcp-coder init command for config`

## Test plan

- [ ] Existing tests from #567 included (`tests/cli/commands/test_init.py`)
- [ ] No conflicts with current `main`