### PR TITLE
fix(vscodeclaude): use local time in status file (#584)

### DIFF
--- a/src/mcp_coder/workflows/vscodeclaude/workspace.py
+++ b/src/mcp_coder/workflows/vscodeclaude/workspace.py
@@ -9,7 +9,7 @@ import shutil
 import stat
 import sys
 from collections.abc import Callable
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -638,7 +638,7 @@ def create_status_file(
         status_name=status,
         repo=repo_full_name,
         branch=branch_name,
-        started_at=datetime.now(timezone.utc).isoformat(),
+        started_at=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         intervention_line=intervention_line,
         issue_url=issue_url,
     )


### PR DESCRIPTION
## Summary
- Use local time instead of UTC in `.vscodeclaude_status.txt`
- Format as `YYYY-MM-DD HH:MM:SS` instead of full ISO-8601 with microseconds and timezone offset
- Remove unused `timezone` import

Closes #584

## Test plan
- [x] Pylint passes
- [x] Mypy passes
- [x] Pytest passes (existing failures unrelated)
- [x] Ruff passes