### PR TITLE
fix(implement): change 'no files changed' log level to info

### DIFF
--- a/src/mcp_coder/workflows/implement/task_processing.py
+++ b/src/mcp_coder/workflows/implement/task_processing.py
@@ -486,11 +486,11 @@ Please implement this task step by step."""
         all_changes = status["staged"] + status["modified"] + status["untracked"]
 
         if not all_changes:
-            logger.warning(f"No files were changed for task: {next_task}")
-            logger.warning(
+            logger.info(f"No files were changed for task: {next_task}")
+            logger.info(
                 "This might indicate the task is already complete or the LLM didn't make changes"
             )
-            logger.warning("Skipping commit/push for this task")
+            logger.info("Skipping commit/push for this task")
             return True, "completed"  # Consider it successful but skip commit
     except (
         Exception


### PR DESCRIPTION
## Summary
- Change 3 `logger.warning()` calls to `logger.info()` in `task_processing.py` when no files are changed after a task
- "No files changed" is a normal outcome (e.g. quality checks finding nothing to fix), not a warning condition

## Test plan
- [x] Pylint: no issues
- [x] Mypy: no type errors
- [x] Pytest: no new failures

Closes #587