### PR TITLE
fix: add snapshot_report.html to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ pr_info/.ci_problem_description.md
 
 # Test artifacts (cleanup safety net)
 temp_integration_test.py
+snapshot_report.html
 
 # Claude auto-memory files (session-local, not for version control)
 memory/


### PR DESCRIPTION
## Summary
- Add `snapshot_report.html` to `.gitignore` to prevent accidental commits
- `pytest-textual-snapshot` generates this file with `dict(os.environ)` embedded for debugging, which leaks CI secrets (GITHUB_TOKEN, JENKINS_*_COOKIE, etc.)
- GitHub Push Protection blocked a push on branch #645 because the report contained a GitHub PAT

## Test plan
- [x] Verify `snapshot_report.html` is listed in `.gitignore`
- [ ] Confirm future `implement` workflow runs no longer commit the report