### PR TITLE
docs(claude): add gh issue/run view to approved commands

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -185,6 +185,8 @@ git commit
 git log
 git fetch
 git ls-tree
+gh issue view
+gh run view
 ./tools/ruff_check.sh
 mcp-coder git-tool compact-diff
 mcp-coder check branch-status


### PR DESCRIPTION
## Summary
- Add `gh issue view` and `gh run view` to the approved commands list in CLAUDE.md
- These were already permitted in `settings.local.json` but missing from the documented approved list

## Test plan
- [x] Verify CLAUDE.md renders correctly