### PR TITLE
feat(tools): add MLflow artifact search and inspect scripts

### DIFF
--- a/tools/inspect_mlflow_run.py
+++ b/tools/inspect_mlflow_run.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Inspect a single MLflow run's conversation in detail.
+
+Shows the full tool call trace for a specific run, useful for debugging
+why a step failed or understanding what Claude did during implementation.
+
+Usage:
+    python tools/inspect_mlflow_run.py <run_id>
+    python tools/inspect_mlflow_run.py <run_id> --step 2
+    python tools/inspect_mlflow_run.py <run_id> --show-content
+    python tools/inspect_mlflow_run.py <run_id> --filter save_file
+"""
+
+import argparse
+import json
+import re
+import sqlite3
+import urllib.parse
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+def get_mlflow_db_path() -> Path:
+    """Get the MLflow database path from config or default location."""
+    config_paths = [
+        Path.home() / ".mcp_coder" / "config.toml",
+        Path.home() / ".config" / "mcp-coder" / "config.toml",
+    ]
+    for config_path in config_paths:
+        if config_path.exists():
+            config_text = config_path.read_text()
+            match = re.search(r'tracking_uri\s*=\s*"sqlite:///([^"]+)"', config_text)
+            if match:
+                db_path = match.group(1)
+                if db_path.startswith("~/"):
+                    db_path = str(Path.home() / db_path[2:])
+                return Path(db_path)
+    return Path.home() / "mlflow_data" / "mlflow.db"
+
+
+def format_timestamp(timestamp_ms: int) -> str:
+    """Format timestamp from milliseconds."""
+    return datetime.fromtimestamp(timestamp_ms / 1000).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def get_run_info(conn: sqlite3.Connection, run_id: str) -> Optional[Dict[str, Any]]:
+    """Get run metadata from database."""
+    cursor = conn.cursor()
+    # Support partial run IDs
+    cursor.execute(
+        """
+        SELECT r.run_uuid, r.name, r.start_time, r.end_time,
+               r.artifact_uri, r.status, e.name
+        FROM runs r
+        JOIN experiments e ON r.experiment_id = e.experiment_id
+        WHERE r.run_uuid LIKE ?
+        """,
+        (run_id + "%",),
+    )
+    row = cursor.fetchone()
+    if not row:
+        return None
+
+    # Get params
+    pcursor = conn.cursor()
+    pcursor.execute("SELECT key, value FROM params WHERE run_uuid = ?", (row[0],))
+    params = {r[0]: r[1] for r in pcursor.fetchall()}
+
+    # Get metrics
+    mcursor = conn.cursor()
+    mcursor.execute("SELECT key, value FROM metrics WHERE run_uuid = ?", (row[0],))
+    metrics = {r[0]: float(r[1]) for r in mcursor.fetchall()}
+
+    return {
+        "run_id": row[0],
+        "name": row[1],
+        "start_time": format_timestamp(row[2]) if row[2] else "N/A",
+        "end_time": format_timestamp(row[3]) if row[3] else "N/A",
+        "artifact_uri": row[4],
+        "status": row[5],
+        "experiment_name": row[6],
+        "params": params,
+        "metrics": metrics,
+    }
+
+
+def get_artifact_base(artifact_uri: str) -> Optional[Path]:
+    """Parse artifact URI to local path."""
+    artifact_path_str = urllib.parse.urlparse(artifact_uri).path
+    if artifact_path_str.startswith("/") and ":" in artifact_path_str:
+        artifact_path_str = artifact_path_str[1:]
+    p = Path(artifact_path_str)
+    return p if p.exists() else None
+
+
+def load_step(base: Path, step_num: int) -> Optional[Dict[str, Any]]:
+    """Load a single step's data."""
+    conv_dir = base / "conversation_data"
+    conv_file = conv_dir / f"step_{step_num}_conversation.json"
+    prompt_file = conv_dir / f"step_{step_num}_prompt.txt"
+    params_file = conv_dir / f"step_{step_num}_all_params.json"
+
+    if not conv_file.exists():
+        return None
+
+    result: Dict[str, Any] = {"step": step_num}
+    try:
+        with open(conv_file, "r", encoding="utf-8") as f:
+            result["conversation"] = json.load(f)
+    except json.JSONDecodeError:
+        return None
+
+    if prompt_file.exists():
+        result["prompt"] = prompt_file.read_text(encoding="utf-8")
+    if params_file.exists():
+        with open(params_file, "r", encoding="utf-8") as f:
+            result["params"] = json.load(f)
+
+    return result
+
+
+def list_steps(base: Path) -> List[int]:
+    """List available step numbers."""
+    conv_dir = base / "conversation_data"
+    if not conv_dir.exists():
+        return []
+    steps = []
+    for f in conv_dir.glob("step_*_conversation.json"):
+        try:
+            steps.append(int(f.name.split("_")[1]))
+        except (ValueError, IndexError):
+            continue
+    return sorted(steps)
+
+
+def safe_print(text: str) -> None:
+    """Print with Unicode fallback."""
+    try:
+        print(text)
+    except UnicodeEncodeError:
+        print(text.encode("ascii", "replace").decode("ascii"))
+
+
+def print_tool_trace(
+    step_data: Dict[str, Any],
+    filter_text: Optional[str] = None,
+    show_content: bool = False,
+    content_limit: int = 500,
+) -> None:
+    """Print the tool call trace for a step."""
+    conv = step_data.get("conversation", {})
+    resp = conv.get("response_data", {})
+    raw = resp.get("raw_response", {})
+    messages = raw.get("messages", [])
+
+    if not messages:
+        # Try simpler format
+        text = resp.get("text", "")
+        if text:
+            safe_print(f"  Response: {text[:content_limit]}")
+        else:
+            print("  (no message data available)")
+        return
+
+    msg_count = 0
+    tool_count = 0
+    error_count = 0
+
+    for i, msg in enumerate(messages):
+        mtype = msg.get("type", "")
+
+        if mtype == "system":
+            subtype = msg.get("subtype", "")
+            if subtype == "init":
+                tools = msg.get("tools", [])
+                print(f"  [{i}] SYSTEM init | {len(tools)} tools available")
+            continue
+
+        if mtype == "user":
+            # Check for tool results
+            tr = msg.get("tool_use_result")
+            if tr:
+                if isinstance(tr, dict):
+                    content_str = str(tr.get("content", ""))
+                    structured = tr.get("structuredContent")
+                else:
+                    content_str = str(tr)
+                    structured = None
+
+                is_error = "error" in content_str.lower() or (
+                    isinstance(structured, dict) and structured.get("is_error")
+                )
+
+                if is_error:
+                    error_count += 1
+
+                if filter_text and filter_text.lower() not in content_str.lower():
+                    continue
+
+                label = "ERROR" if is_error else "RESULT"
+                preview = content_str[:content_limit] if show_content else content_str[:150]
+                safe_print(f"  [{i}] {label}: {preview}")
+            else:
+                # User message
+                um = msg.get("message", {})
+                if isinstance(um, dict):
+                    c = um.get("content", "")
+                    if isinstance(c, str) and c.strip():
+                        preview = c[:200]
+                        safe_print(f"  [{i}] USER: {preview}")
+            continue
+
+        if mtype == "assistant":
+            content = msg.get("message", {}).get("content", [])
+            if not isinstance(content, list):
+                continue
+
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                bt = block.get("type", "")
+
+                if bt == "tool_use":
+                    tool_count += 1
+                    name = block.get("name", "?")
+                    inp = block.get("input", {})
+
+                    if filter_text and filter_text.lower() not in name.lower():
+                        inp_str = json.dumps(inp)
+                        if filter_text.lower() not in inp_str.lower():
+                            continue
+
+                    # Format input concisely
+                    if "file_path" in inp:
+                        summary = f"file={inp['file_path']}"
+                    elif "command" in inp:
+                        cmd = inp["command"]
+                        summary = f"cmd={cmd[:120]}"
+                    elif "pattern" in inp:
+                        summary = f"pattern={inp['pattern']}"
+                    elif "prompt" in inp:
+                        summary = f"prompt={str(inp['prompt'])[:80]}"
+                    else:
+                        summary = json.dumps(inp)[:150]
+
+                    safe_print(f"  [{i}] CALL: {name} | {summary}")
+
+                    if show_content and inp:
+                        for k, v in inp.items():
+                            if k in ("file_path", "command", "pattern"):
+                                continue
+                            vstr = str(v)[:content_limit]
+                            safe_print(f"         {k}: {vstr}")
+
+                elif bt == "text":
+                    t = block.get("text", "")
+                    if t.strip():
+                        if filter_text and filter_text.lower() not in t.lower():
+                            continue
+                        msg_count += 1
+                        safe_print(f"  [{i}] TEXT: {t[:300]}")
+
+                elif bt == "thinking":
+                    # Skip thinking blocks unless showing content
+                    if show_content:
+                        t = block.get("thinking", "")[:200]
+                        if filter_text and filter_text.lower() not in t.lower():
+                            continue
+                        safe_print(f"  [{i}] THINKING: {t}")
+
+            continue
+
+        if mtype == "result":
+            is_err = msg.get("is_error", False)
+            result_text = str(msg.get("result", ""))
+            label = "FINAL_ERROR" if is_err else "FINAL"
+            safe_print(f"  [{i}] {label}: {result_text[:content_limit]}")
+
+    print(f"\n  Summary: {len(messages)} messages, {tool_count} tool calls, {error_count} errors")
+
+
+def main() -> None:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Inspect a single MLflow run's conversation trace",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "run_id", help="Run ID (full or prefix)"
+    )
+    parser.add_argument(
+        "--step",
+        type=int,
+        help="Show only this step number (default: all steps)",
+    )
+    parser.add_argument(
+        "--filter",
+        type=str,
+        help="Filter trace to entries matching this text",
+    )
+    parser.add_argument(
+        "--show-content",
+        action="store_true",
+        help="Show full tool input/output content",
+    )
+    parser.add_argument(
+        "--content-limit",
+        type=int,
+        default=500,
+        help="Max chars for content display (default: 500)",
+    )
+    parser.add_argument(
+        "--prompt-only",
+        action="store_true",
+        help="Only show the prompt text for each step",
+    )
+    parser.add_argument(
+        "--db-path", type=str, help="Path to MLflow SQLite database"
+    )
+
+    args = parser.parse_args()
+
+    db_path = Path(args.db_path) if args.db_path else get_mlflow_db_path()
+    if not db_path.exists():
+        print(f"Error: MLflow database not found at {db_path}")
+        return
+
+    conn = sqlite3.connect(db_path)
+    try:
+        run = get_run_info(conn, args.run_id)
+        if not run:
+            print(f"Error: No run found matching '{args.run_id}'")
+            return
+
+        # Print run header
+        print("=" * 80)
+        print(f"Run: {run['run_id']}")
+        print(f"Name: {run['name']}")
+        print(f"Experiment: {run['experiment_name']}")
+        print(f"Status: {run['status']}")
+        print(f"Time: {run['start_time']} -> {run['end_time']}")
+        if run["params"]:
+            print("Params:")
+            for k, v in sorted(run["params"].items()):
+                print(f"  {k}: {v}")
+        if run["metrics"]:
+            print("Metrics:")
+            for k, v in sorted(run["metrics"].items()):
+                print(f"  {k}: {v:.2f}")
+        print("=" * 80)
+
+        base = get_artifact_base(run["artifact_uri"])
+        if not base:
+            print(f"\nArtifact directory not found: {run['artifact_uri']}")
+            return
+
+        steps = list_steps(base)
+        if not steps:
+            print("\nNo conversation steps found in artifacts.")
+            return
+
+        if args.step is not None:
+            steps = [args.step] if args.step in steps else []
+            if not steps:
+                print(f"\nStep {args.step} not found. Available: {list_steps(base)}")
+                return
+
+        for step_num in steps:
+            step_data = load_step(base, step_num)
+            if not step_data:
+                continue
+
+            print(f"\n{'─' * 40} Step {step_num} {'─' * 40}")
+
+            prompt = step_data.get("prompt", "")
+            if prompt:
+                preview = prompt[:500] if not args.show_content else prompt[:2000]
+                safe_print(f"Prompt: {preview}")
+                if len(prompt) > len(preview):
+                    print(f"  ... ({len(prompt)} chars total)")
+
+            if not args.prompt_only:
+                print("\nTool Trace:")
+                print_tool_trace(
+                    step_data,
+                    filter_text=args.filter,
+                    show_content=args.show_content,
+                    content_limit=args.content_limit,
+                )
+
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/search_mlflow_artifacts.py
+++ b/tools/search_mlflow_artifacts.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Search MLflow conversation artifacts by text content.
+
+Searches prompt text, response text, and tool calls across all MLflow runs.
+
+Usage:
+    python tools/search_mlflow_artifacts.py "680"
+    python tools/search_mlflow_artifacts.py "task tracker" --field prompt
+    python tools/search_mlflow_artifacts.py "save_file" --field tools --limit 10
+    python tools/search_mlflow_artifacts.py "pr_info" --branch 680-refactor
+"""
+
+import argparse
+import json
+import re
+import sqlite3
+import urllib.parse
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+def get_mlflow_db_path() -> Path:
+    """Get the MLflow database path from config or default location."""
+    config_paths = [
+        Path.home() / ".mcp_coder" / "config.toml",
+        Path.home() / ".config" / "mcp-coder" / "config.toml",
+    ]
+    for config_path in config_paths:
+        if config_path.exists():
+            config_text = config_path.read_text()
+            match = re.search(r'tracking_uri\s*=\s*"sqlite:///([^"]+)"', config_text)
+            if match:
+                db_path = match.group(1)
+                if db_path.startswith("~/"):
+                    db_path = str(Path.home() / db_path[2:])
+                return Path(db_path)
+    return Path.home() / "mlflow_data" / "mlflow.db"
+
+
+def format_timestamp(timestamp_ms: int) -> str:
+    """Format timestamp from milliseconds."""
+    return datetime.fromtimestamp(timestamp_ms / 1000).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def get_all_runs(
+    conn: sqlite3.Connection,
+    limit: int = 50,
+    branch: Optional[str] = None,
+    working_dir: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Get runs with optional filters."""
+    cursor = conn.cursor()
+    query = """
+        SELECT r.run_uuid, r.name, r.start_time, r.end_time,
+               r.artifact_uri, r.status, e.name as experiment_name
+        FROM runs r
+        JOIN experiments e ON r.experiment_id = e.experiment_id
+        WHERE r.lifecycle_stage = 'active'
+        ORDER BY r.start_time DESC
+        LIMIT ?
+    """
+    cursor.execute(query, (limit,))
+
+    runs = []
+    for row in cursor.fetchall():
+        run_id = row[0]
+
+        # Get params for filtering
+        pcursor = conn.cursor()
+        pcursor.execute(
+            "SELECT key, value FROM params WHERE run_uuid = ?", (run_id,)
+        )
+        params = {r[0]: r[1] for r in pcursor.fetchall()}
+
+        # Apply filters
+        if branch and params.get("branch_name", "") != branch:
+            if branch not in params.get("branch_name", ""):
+                continue
+        if working_dir and working_dir.lower() not in params.get(
+            "working_directory", ""
+        ).lower():
+            continue
+
+        runs.append(
+            {
+                "run_id": run_id,
+                "name": row[1],
+                "start_time": format_timestamp(row[2]) if row[2] else "N/A",
+                "start_time_ms": row[2],
+                "end_time": format_timestamp(row[3]) if row[3] else "N/A",
+                "artifact_uri": row[4],
+                "status": row[5],
+                "experiment_name": row[6],
+                "params": params,
+            }
+        )
+    return runs
+
+
+def get_artifact_base(artifact_uri: str) -> Optional[Path]:
+    """Parse artifact URI to local path."""
+    artifact_path_str = urllib.parse.urlparse(artifact_uri).path
+    if artifact_path_str.startswith("/") and ":" in artifact_path_str:
+        artifact_path_str = artifact_path_str[1:]
+    p = Path(artifact_path_str)
+    return p if p.exists() else None
+
+
+def load_step_conversations(artifact_uri: str) -> List[Dict[str, Any]]:
+    """Load all step conversation files from a run's artifacts."""
+    base = get_artifact_base(artifact_uri)
+    if not base:
+        return []
+
+    conv_dir = base / "conversation_data"
+    if not conv_dir.exists():
+        return []
+
+    steps = []
+    # Try step_N pattern first
+    for step_file in sorted(conv_dir.glob("step_*_conversation.json")):
+        try:
+            with open(step_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            # Also load the prompt file
+            step_num = step_file.name.split("_")[1]
+            prompt_file = conv_dir / f"step_{step_num}_prompt.txt"
+            prompt_text = ""
+            if prompt_file.exists():
+                prompt_text = prompt_file.read_text(encoding="utf-8")
+            steps.append(
+                {"step": int(step_num), "conversation": data, "prompt": prompt_text}
+            )
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+    # Try legacy conversation.json
+    if not steps:
+        legacy = conv_dir / "conversation.json"
+        if legacy.exists():
+            try:
+                with open(legacy, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                steps.append(
+                    {
+                        "step": 0,
+                        "conversation": data,
+                        "prompt": data.get("prompt", ""),
+                    }
+                )
+            except json.JSONDecodeError:
+                pass
+
+    return steps
+
+
+def extract_searchable_text(
+    step: Dict[str, Any], field: str
+) -> List[Dict[str, str]]:
+    """Extract searchable text blocks from a step conversation."""
+    results = []
+    conv = step.get("conversation", {})
+    prompt = step.get("prompt", "")
+
+    if field in ("all", "prompt"):
+        if prompt:
+            results.append({"field": "prompt", "text": prompt})
+
+    resp = conv.get("response_data", {})
+
+    if field in ("all", "response"):
+        text = resp.get("text", "")
+        if text:
+            results.append({"field": "response", "text": text})
+
+    # Extract from raw_response messages
+    raw = resp.get("raw_response", {})
+    messages = raw.get("messages", [])
+
+    for msg in messages:
+        content = msg.get("message", {}).get("content", [])
+
+        if isinstance(content, list):
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                bt = block.get("type", "")
+
+                if bt == "tool_use" and field in ("all", "tools"):
+                    name = block.get("name", "")
+                    inp = json.dumps(block.get("input", {}))
+                    results.append(
+                        {"field": f"tool_call:{name}", "text": name + " " + inp}
+                    )
+
+                if bt == "text" and field in ("all", "response"):
+                    t = block.get("text", "")
+                    if t.strip():
+                        results.append(
+                            {"field": "assistant_text", "text": t}
+                        )
+
+        # Tool results
+        tr = msg.get("tool_use_result")
+        if tr and field in ("all", "results"):
+            if isinstance(tr, dict):
+                content_str = str(tr.get("content", ""))
+            else:
+                content_str = str(tr)
+            if content_str.strip():
+                results.append({"field": "tool_result", "text": content_str})
+
+    return results
+
+
+def search_runs(
+    runs: List[Dict[str, Any]],
+    query: str,
+    field: str = "all",
+    case_sensitive: bool = False,
+) -> List[Dict[str, Any]]:
+    """Search across all runs for matching text."""
+    matches = []
+    flags = 0 if case_sensitive else re.IGNORECASE
+
+    for run in runs:
+        steps = load_step_conversations(run["artifact_uri"])
+        run_matches = []
+
+        for step in steps:
+            texts = extract_searchable_text(step, field)
+            for entry in texts:
+                if re.search(query, entry["text"], flags):
+                    # Extract context around match
+                    m = re.search(query, entry["text"], flags)
+                    if m:
+                        start = max(0, m.start() - 80)
+                        end = min(len(entry["text"]), m.end() + 80)
+                        context = entry["text"][start:end]
+                        if start > 0:
+                            context = "..." + context
+                        if end < len(entry["text"]):
+                            context = context + "..."
+
+                    run_matches.append(
+                        {
+                            "step": step["step"],
+                            "field": entry["field"],
+                            "context": context,
+                        }
+                    )
+
+        if run_matches:
+            matches.append(
+                {
+                    "run": run,
+                    "matches": run_matches,
+                }
+            )
+
+    return matches
+
+
+def safe_print(text: str) -> None:
+    """Print with Unicode fallback."""
+    try:
+        print(text)
+    except UnicodeEncodeError:
+        print(text.encode("ascii", "replace").decode("ascii"))
+
+
+def main() -> None:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Search MLflow conversation artifacts by text content",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("query", help="Text or regex to search for")
+    parser.add_argument(
+        "--field",
+        choices=["all", "prompt", "response", "tools", "results"],
+        default="all",
+        help="Which field to search (default: all)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Max runs to scan (default: 50)",
+    )
+    parser.add_argument(
+        "--branch", type=str, help="Filter by branch name (substring match)"
+    )
+    parser.add_argument(
+        "--working-dir",
+        type=str,
+        help="Filter by working directory (substring match)",
+    )
+    parser.add_argument(
+        "--case-sensitive", action="store_true", help="Case-sensitive search"
+    )
+    parser.add_argument(
+        "--db-path", type=str, help="Path to MLflow SQLite database"
+    )
+
+    args = parser.parse_args()
+
+    db_path = Path(args.db_path) if args.db_path else get_mlflow_db_path()
+    if not db_path.exists():
+        print(f"Error: MLflow database not found at {db_path}")
+        return
+
+    print(f"Database: {db_path}")
+    print(f"Searching for: {args.query!r} in field={args.field}")
+    if args.branch:
+        print(f"Branch filter: {args.branch}")
+    if args.working_dir:
+        print(f"Working dir filter: {args.working_dir}")
+    print()
+
+    conn = sqlite3.connect(db_path)
+    try:
+        runs = get_all_runs(conn, args.limit, args.branch, args.working_dir)
+        print(f"Scanning {len(runs)} runs...")
+        matches = search_runs(runs, args.query, args.field, args.case_sensitive)
+
+        print(f"Found {len(matches)} runs with matches.\n")
+        print("=" * 80)
+
+        for hit in matches:
+            run = hit["run"]
+            branch = run["params"].get("branch_name", "N/A")
+            wdir = run["params"].get("working_directory", "N/A")
+            print(f"\nRun: {run['run_id']}")
+            print(f"  Time: {run['start_time']} -> {run['end_time']}")
+            print(f"  Branch: {branch}")
+            print(f"  Working Dir: {wdir}")
+            print(f"  Status: {run['status']}")
+            print(f"  Matches ({len(hit['matches'])}):")
+
+            for m in hit["matches"]:
+                safe_print(f"    [step {m['step']}] {m['field']}:")
+                safe_print(f"      {m['context']}")
+            print("-" * 80)
+
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- **search_mlflow_artifacts.py**: Full-text search across MLflow run conversations (prompts, responses, tool calls, results) with branch/directory filters
- **inspect_mlflow_run.py**: Detailed tool call trace viewer for a single run with partial ID support, step selection, and text filtering

These tools were created while debugging a #680 implementation failure where `mcp__workspace__save_file` reported success but files weren't persisted between Jenkins runs.

## Test plan
- [x] `search_mlflow_artifacts.py "680" --field prompt` finds matching runs
- [x] `inspect_mlflow_run.py c997f1ba --filter pr_info` shows tool trace
- [x] Pylint clean
- [x] Mypy clean
- [x] Ruff clean