### PR TITLE
fix(icoder): reuse prepare_llm_environment for correct venv detection

### DIFF
--- a/pr_info/implementation_review_log_1.md
+++ b/pr_info/implementation_review_log_1.md
@@ -1,0 +1,19 @@
+# Implementation Review Log — fix/icoder-env-reuse-prepare-llm-environment
+
+## Round 1 — 2026-04-10
+**Findings**:
+- Correct delegation to shared `prepare_llm_environment` (Accept — confirmed correct)
+- Removed imports (`os`, `get_bin_dir`) are genuinely unused (Accept — confirmed correct)
+- Removed tests for old preset-env-var behavior are appropriate (Accept — that logic moved to shared function)
+- Mock replacement in tests is correct and platform-aware (Accept — confirmed correct)
+- Behavioral change: preset env vars no longer override — intentional, shared function is source of truth (Accept — confirmed correct)
+- `env_vars` dict passes through directly from shared function (Accept — clean and correct)
+- `_clear_mcp_env` fixture may be unnecessary now (Skip — harmless defense-in-depth)
+- No integration test for real `prepare_llm_environment` call (Skip — shared function has own tests in `tests/llm/test_env.py`)
+
+**Decisions**: All findings confirm implementation is correct. No code changes needed.
+**Changes**: None
+**Status**: No changes needed
+
+## Final Status
+Review complete. Implementation is correct, clean, and properly eliminates duplication. No issues found.

--- a/src/mcp_coder/icoder/env_setup.py
+++ b/src/mcp_coder/icoder/env_setup.py
@@ -11,17 +11,16 @@ from __future__ import annotations
 
 import importlib.metadata
 import logging
-import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from mcp_coder.llm.env import prepare_llm_environment
 from mcp_coder.llm.providers.claude.claude_executable_finder import (
     find_claude_executable,
 )
 from mcp_coder.utils.mcp_verification import (
     MCPServerInfo,
-    get_bin_dir,
     verify_mcp_servers,
 )
 
@@ -77,8 +76,10 @@ def setup_icoder_environment(project_dir: Path) -> RuntimeInfo:
     Returns:
         RuntimeInfo with resolved paths, environment variables, and MCP server details.
     """
-    tool_env = sys.prefix
-    bin_dir = get_bin_dir(Path(tool_env))
+    # Reuse shared env var logic (VIRTUAL_ENV > CONDA_PREFIX > sys.prefix)
+    effective = prepare_llm_environment(project_dir)
+
+    tool_env = effective["MCP_CODER_VENV_DIR"]
 
     project_venv = project_dir / ".venv"
     if not project_venv.exists():
@@ -87,24 +88,6 @@ def setup_icoder_environment(project_dir: Path) -> RuntimeInfo:
             project_venv,
         )
         project_venv = Path(tool_env)
-
-    computed = {
-        "MCP_CODER_VENV_PATH": str(bin_dir),
-        "MCP_CODER_VENV_DIR": str(tool_env),
-        "MCP_CODER_PROJECT_DIR": str(project_dir),
-    }
-
-    effective: dict[str, str] = {}
-    for key, value in computed.items():
-        existing = os.environ.get(key)
-        if existing is None:
-            effective[key] = value
-        else:
-            if existing != value:
-                logger.debug(
-                    "%s already set to %s (computed: %s)", key, existing, value
-                )
-            effective[key] = existing
 
     mcp_servers = verify_mcp_servers(tool_env)
     version = importlib.metadata.version("mcp-coder")

--- a/tests/icoder/test_env_setup.py
+++ b/tests/icoder/test_env_setup.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import logging
-import os
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -48,8 +46,17 @@ def _mock_externals(
     monkeypatch: pytest.MonkeyPatch,
     fake_venv: Path,
 ) -> None:
-    """Mock sys.prefix, verify_mcp_servers, importlib.metadata.version, and claude."""
-    monkeypatch.setattr(sys, "prefix", str(fake_venv))
+    """Mock prepare_llm_environment, verify_mcp_servers, metadata.version, and claude."""
+    subdir = "Scripts" if sys.platform == "win32" else "bin"
+    bin_dir = fake_venv / subdir
+    monkeypatch.setattr(
+        "mcp_coder.icoder.env_setup.prepare_llm_environment",
+        lambda project_dir: {
+            "MCP_CODER_VENV_PATH": str(bin_dir),
+            "MCP_CODER_VENV_DIR": str(fake_venv),
+            "MCP_CODER_PROJECT_DIR": str(project_dir),
+        },
+    )
     monkeypatch.setattr(
         "mcp_coder.icoder.env_setup.verify_mcp_servers",
         lambda _root: _FAKE_MCP_SERVERS,
@@ -89,8 +96,8 @@ class TestSetupIcoderEnvironment:
         assert "MCP_CODER_VENV_DIR" in info.env_vars
         assert "MCP_CODER_PROJECT_DIR" in info.env_vars
 
-    def test_tool_env_uses_sys_prefix(self, tmp_path: Path, fake_venv: Path) -> None:
-        """tool_env_path should equal sys.prefix."""
+    def test_tool_env_uses_detected_venv(self, tmp_path: Path, fake_venv: Path) -> None:
+        """tool_env_path should equal the detected venv from prepare_llm_environment."""
         project_dir = tmp_path / "project"
         project_dir.mkdir()
 
@@ -123,51 +130,6 @@ class TestSetupIcoderEnvironment:
         assert info.project_venv_path == str(fake_venv)
         assert any("No project .venv found" in msg for msg in caplog.messages)
 
-    @pytest.mark.parametrize(
-        "key",
-        ["MCP_CODER_VENV_PATH", "MCP_CODER_VENV_DIR", "MCP_CODER_PROJECT_DIR"],
-    )
-    def test_respects_preset_env_vars(
-        self,
-        tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
-        key: str,
-    ) -> None:
-        """Pre-set env var wins over computed value."""
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        preset_value = "/preset/value"
-        monkeypatch.setenv(key, preset_value)
-
-        # Snapshot environ before
-        env_before = dict(os.environ)
-
-        info = setup_icoder_environment(project_dir)
-
-        assert info.env_vars[key] == preset_value
-        # os.environ should not have been mutated beyond the monkeypatch
-        assert os.environ[key] == env_before[key]
-
-    def test_logs_debug_when_preset_differs(
-        self,
-        tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
-        caplog: pytest.LogCaptureFixture,
-    ) -> None:
-        """DEBUG log emitted when pre-set value differs from computed."""
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        monkeypatch.setenv("MCP_CODER_VENV_DIR", "/different/path")
-
-        with caplog.at_level(logging.DEBUG, logger="mcp_coder.icoder.env_setup"):
-            info = setup_icoder_environment(project_dir)
-
-        assert info.env_vars["MCP_CODER_VENV_DIR"] == "/different/path"
-        assert any(
-            "MCP_CODER_VENV_DIR" in msg and "already set" in msg
-            for msg in caplog.messages
-        )
-
     def test_env_vars_always_contain_all_three_keys(self, tmp_path: Path) -> None:
         """With no pre-set vars, all three MCP_CODER_* keys present."""
         project_dir = tmp_path / "project"
@@ -181,18 +143,6 @@ class TestSetupIcoderEnvironment:
             "MCP_CODER_PROJECT_DIR",
         }
         assert expected_keys == set(info.env_vars.keys())
-
-    def test_does_not_mutate_os_environ(self, tmp_path: Path) -> None:
-        """No new MCP_CODER_* keys added to os.environ."""
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-
-        mcp_keys_before = {k for k in os.environ if k.startswith("MCP_CODER_")}
-
-        setup_icoder_environment(project_dir)
-
-        mcp_keys_after = {k for k in os.environ if k.startswith("MCP_CODER_")}
-        assert mcp_keys_after == mcp_keys_before
 
     def test_mcp_servers_verified(self, tmp_path: Path) -> None:
         """mcp_servers in RuntimeInfo comes from verify_mcp_servers."""


### PR DESCRIPTION
## Summary
- **Bug**: icoder used `sys.prefix` directly for venv detection, while `prompt` used `prepare_llm_environment()` which correctly checks `VIRTUAL_ENV > CONDA_PREFIX > sys.prefix`. This caused MCP tools-py to get the wrong Python path in icoder, breaking tool availability.
- **Fix**: Replace duplicated env var logic in `setup_icoder_environment()` with a call to the shared `prepare_llm_environment()` from `llm/env.py` (DRY).
- **Net change**: -85 lines, +18 lines — removed duplication, both commands now share the same code path.

## Test plan
- [x] All 6 `tests/icoder/test_env_setup.py` tests pass
- [x] Pylint, lint-imports, vulture, ruff all clean
- [ ] Manual: run `mcp-coder icoder` and verify tools-py MCP tools are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)