### PR TITLE
fix(skill): increase CI timeout in implementation_approve

### DIFF
--- a/.claude/skills/implementation_approve/SKILL.md
+++ b/.claude/skills/implementation_approve/SKILL.md
@@ -13,7 +13,7 @@ Approve the implementation and transition the issue to PR-ready state.
 **Instructions:**
 1. Run branch-status check:
 ```bash
-mcp-coder check branch-status --ci-timeout 400 --pr-timeout 600 --llm-truncate
+mcp-coder check branch-status --ci-timeout 600 --pr-timeout 600 --llm-truncate
 ```
 
 2. If `branch-status` reports a base branch other than `main`, ask the user to confirm this is intentional before proceeding.
@@ -29,5 +29,5 @@ mcp-coder gh-tool set-status status-08:ready-pr
 
 4. After the label is set, poll for the PR to be created and pass CI. This runs in the background — the background process creates the PR while it polls (up to 600s):
 ```bash
-mcp-coder check branch-status --ci-timeout 400 --pr-timeout 600 --llm-truncate --wait-for-pr
+mcp-coder check branch-status --ci-timeout 600 --pr-timeout 600 --llm-truncate --wait-for-pr
 ```


### PR DESCRIPTION
## Summary
- Increase `--ci-timeout` from 400s to 600s in the `implementation_approve` skill
- CI often needs more than 400s, causing the background poll to exit before results are available

## Test plan
- [x] Verify both occurrences updated in SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)