### PR TITLE
feat(implement): add pyproject config for format/type-check gating

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -338,3 +338,7 @@ packages = [
 packages-no-deps = [
     "mcp-tools-py @ git+https://github.com/MarcusJellinghaus/mcp-tools-py.git",
 ]
+
+[tool.mcp-coder.implement]
+format_code = true
+check_type_hints = true

--- a/src/mcp_coder/cli/commands/verify.py
+++ b/src/mcp_coder/cli/commands/verify.py
@@ -24,6 +24,7 @@ from ...llm.providers.claude.claude_cli_verification import verify_claude
 from ...llm.providers.claude.claude_executable_finder import find_claude_executable
 from ...prompts.prompt_loader import get_project_prompt_path, is_claude_md, load_prompts
 from ...utils.mcp_verification import ClaudeMCPStatus, parse_claude_mcp_list
+from ...utils.pyproject_config import get_implement_config
 from ...utils.user_config import verify_config
 from ..utils import resolve_llm_method, resolve_mcp_config_path
 
@@ -98,6 +99,35 @@ def _print_environment_section() -> None:
         except PackageNotFoundError:
             value = "[ERR] not installed"
         print(f"  {pkg:<20s} {value}")
+
+
+def _print_project_section(project_dir: Path, symbols: dict[str, str]) -> None:
+    """Print the PROJECT section showing language detection and tool config."""
+    print(_pad("PROJECT"))
+    pyproject_exists = (project_dir / "pyproject.toml").exists()
+    if pyproject_exists:
+        print(f"  {'pyproject.toml':<20s} {symbols['success']} found")
+        print(f"  {'Language':<20s} {symbols['success']} Python (detected)")
+        config = get_implement_config(project_dir)
+        print()
+        print("  [Python]")
+        if config.format_code:
+            print(f"    {'format_code':<18s} {symbols['success']} enabled")
+        else:
+            print(
+                f"    {'format_code':<18s} {symbols['warning']}"
+                " not configured (default: disabled)"
+            )
+        if config.check_type_hints:
+            print(f"    {'check_type_hints':<18s} {symbols['success']} enabled")
+        else:
+            print(
+                f"    {'check_type_hints':<18s} {symbols['warning']}"
+                " not configured (default: disabled)"
+            )
+    else:
+        print(f"  {'pyproject.toml':<20s} {symbols['warning']} not found")
+        print(f"  {'Language':<20s} {symbols['success']} (none detected)")
 
 
 def _pad(title: str) -> str:
@@ -488,6 +518,9 @@ def execute_verify(args: argparse.Namespace) -> int:
                 " project prompt is CLAUDE.md (will skip for Claude)"
             )
     print("\n".join(prompt_lines))
+
+    # 0c. Project configuration section
+    _print_project_section(project_dir, symbols)
 
     # 1. Resolve active provider (already done above)
 

--- a/src/mcp_coder/llm/formatting/stream_renderer.py
+++ b/src/mcp_coder/llm/formatting/stream_renderer.py
@@ -123,10 +123,14 @@ def _render_output_value(value: object) -> list[str]:
                     lines.append(f"{key}:")
                     for sub in rendered:
                         lines.append(f"  {sub}")
+            elif isinstance(child, str):
+                lines.append(f"{key}: {child}")
             else:
                 lines.append(f"{key}: {json.dumps(child)}")
         return lines
     if isinstance(value, list):
+        if all(isinstance(item, str) for item in value):
+            return list(value)
         compact = json.dumps(value)
         if len(compact) <= _MAX_INLINE_LEN:
             return [compact]

--- a/src/mcp_coder/utils/pyproject_config.py
+++ b/src/mcp_coder/utils/pyproject_config.py
@@ -74,6 +74,14 @@ def get_prompts_config(project_dir: Path) -> PromptsConfig:
     )
 
 
+@dataclass(frozen=True)
+class ImplementConfig:
+    """Configuration for the implement workflow."""
+
+    format_code: bool
+    check_type_hints: bool
+
+
 def get_github_install_config(project_dir: Path) -> GitHubInstallConfig:
     """Read [tool.mcp-coder.install-from-github] from pyproject.toml.
 
@@ -97,4 +105,30 @@ def get_github_install_config(project_dir: Path) -> GitHubInstallConfig:
     return GitHubInstallConfig(
         packages=gh.get("packages", []),
         packages_no_deps=gh.get("packages-no-deps", []),
+    )
+
+
+def get_implement_config(project_dir: Path) -> ImplementConfig:
+    """Read [tool.mcp-coder.implement] from pyproject.toml.
+
+    Args:
+        project_dir: Path to directory containing pyproject.toml.
+
+    Returns:
+        ImplementConfig with format_code and check_type_hints booleans.
+    """
+    path = project_dir / "pyproject.toml"
+    if not path.exists():
+        return ImplementConfig(format_code=False, check_type_hints=False)
+
+    try:
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+    except (tomllib.TOMLDecodeError, OSError):
+        return ImplementConfig(format_code=False, check_type_hints=False)
+
+    section = data.get("tool", {}).get("mcp-coder", {}).get("implement", {})
+    return ImplementConfig(
+        format_code=section.get("format_code", False),
+        check_type_hints=section.get("check_type_hints", False),
     )

--- a/src/mcp_coder/workflows/implement/core.py
+++ b/src/mcp_coder/workflows/implement/core.py
@@ -27,6 +27,7 @@ from mcp_coder.utils.git_operations.branch_queries import (
 )
 from mcp_coder.utils.git_utils import get_branch_name_for_logging
 from mcp_coder.utils.github_operations.issues import IssueManager
+from mcp_coder.utils.pyproject_config import get_implement_config
 from mcp_coder.workflow_utils.base_branch import detect_base_branch
 from mcp_coder.workflow_utils.commit_operations import generate_commit_message_with_llm
 from mcp_coder.workflow_utils.failure_handling import (
@@ -553,6 +554,9 @@ def run_implement_workflow(
         logger.debug("Could not register SIGTERM handler")
 
     try:
+        # Read implement config from pyproject.toml
+        implement_config = get_implement_config(project_dir)
+
         # Step 2: Prepare task tracker if needed
         if not prepare_task_tracker(project_dir, provider, mcp_config, execution_dir):
             _handle_workflow_failure(
@@ -586,7 +590,12 @@ def run_implement_workflow(
         # Step 4: Process all incomplete tasks in a loop
         while True:
             success, reason = process_task_with_retry(
-                project_dir, provider, mcp_config, execution_dir
+                project_dir,
+                provider,
+                mcp_config,
+                execution_dir,
+                format_code=implement_config.format_code,
+                check_type_hints=implement_config.check_type_hints,
             )
 
             if not success:
@@ -658,7 +667,11 @@ def run_implement_workflow(
             log_progress_summary(project_dir)
 
         # Step 5: Run final mypy check if not running after each task
-        if not RUN_MYPY_AFTER_EACH_TASK and completed_tasks > 0:
+        if (
+            not RUN_MYPY_AFTER_EACH_TASK
+            and completed_tasks > 0
+            and implement_config.check_type_hints
+        ):
             logger.info("Running final mypy check after all tasks...")
             env_vars = prepare_llm_environment(project_dir)
 
@@ -676,7 +689,7 @@ def run_implement_workflow(
                 )
 
             # Format code after mypy fixes
-            if not run_formatters(project_dir):
+            if implement_config.format_code and not run_formatters(project_dir):
                 logger.error("Formatting failed after final mypy check")
                 _handle_workflow_failure(
                     WorkflowFailure(

--- a/src/mcp_coder/workflows/implement/task_processing.py
+++ b/src/mcp_coder/workflows/implement/task_processing.py
@@ -394,6 +394,8 @@ def process_single_task(
     mcp_config: str | None = None,
     execution_dir: Optional[Path] = None,
     attempt: int = 1,
+    format_code: bool = False,
+    check_type_hints: bool = False,
 ) -> tuple[bool, str]:
     """Process a single implementation task.
 
@@ -403,6 +405,8 @@ def process_single_task(
         mcp_config: Optional path to MCP configuration file
         execution_dir: Optional working directory for Claude subprocess
         attempt: 1-based attempt number; appends retry reminder when > 1
+        format_code: If True, run code formatters after implementation
+        check_type_hints: If True, run mypy type checking after implementation
 
     Returns:
         Tuple of (success, reason) where:
@@ -513,19 +517,22 @@ Please implement this task step by step."""
         return False, "error"
 
     # Step 7: Run mypy check and fixes (each fix will be saved separately)
-    if RUN_MYPY_AFTER_EACH_TASK:
+    if check_type_hints and RUN_MYPY_AFTER_EACH_TASK:
         if not check_and_fix_mypy(
             project_dir, step_num, provider, env_vars, mcp_config, execution_dir
         ):
             logger.warning(
                 "Mypy check failed or found unresolved issues - continuing anyway"
             )
+    elif not check_type_hints:
+        logger.info("Skipping mypy check (check_type_hints disabled)")
     else:
         logger.info("Skipping mypy check (will run after all tasks complete)")
 
     # Step 8: Run formatters
-    if not run_formatters(project_dir):
-        return False, "error"
+    if format_code:
+        if not run_formatters(project_dir):
+            return False, "error"
 
     # Step 9: Commit changes
     if not commit_changes(project_dir, provider):
@@ -544,6 +551,8 @@ def process_task_with_retry(
     provider: str,
     mcp_config: str | None = None,
     execution_dir: Optional[Path] = None,
+    format_code: bool = False,
+    check_type_hints: bool = False,
 ) -> tuple[bool, str]:
     """Process a single task with bounded retry on zero-change results.
 
@@ -562,6 +571,8 @@ def process_task_with_retry(
             mcp_config=mcp_config,
             execution_dir=execution_dir,
             attempt=attempt,
+            format_code=format_code,
+            check_type_hints=check_type_hints,
         )
         if reason != "no_changes":
             return success, reason

--- a/tests/cli/commands/test_verify.py
+++ b/tests/cli/commands/test_verify.py
@@ -4,6 +4,7 @@
 import argparse
 import sys
 from contextlib import ExitStack
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -12,6 +13,7 @@ import pytest
 from mcp_coder.cli.commands.verify import (
     _looks_like_key,
     _print_environment_section,
+    _print_project_section,
     _prompt_source,
     execute_verify,
 )
@@ -468,3 +470,64 @@ class TestConfigGrouping:
         assert not any(line.startswith("    [OK]              ") for line in lines)
         # Must not double the [OK] prefix
         assert not any("[OK] [OK]" in line for line in lines)
+
+
+# ── Project section tests ───────────────────────────────────────────
+
+
+class TestProjectSection:
+    """Tests for the _print_project_section helper."""
+
+    def test_project_section_python_both_enabled(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """pyproject.toml with both options true shows [OK] enabled."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            "[tool.mcp-coder.implement]\n"
+            "format_code = true\n"
+            "check_type_hints = true\n",
+            encoding="utf-8",
+        )
+        symbols = {"success": "[OK]", "failure": "[ERR]", "warning": "[WARN]"}
+        _print_project_section(tmp_path, symbols)
+        out = capsys.readouterr().out
+        assert "=== PROJECT" in out
+        assert "[OK] found" in out
+        assert "[OK] Python (detected)" in out
+        assert "format_code" in out and "[OK] enabled" in out
+        assert "check_type_hints" in out and "[OK] enabled" in out
+
+    def test_project_section_python_defaults(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """pyproject.toml without implement section shows [WARN] not configured."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("[project]\nname = 'demo'\n", encoding="utf-8")
+        symbols = {"success": "[OK]", "failure": "[ERR]", "warning": "[WARN]"}
+        _print_project_section(tmp_path, symbols)
+        out = capsys.readouterr().out
+        assert "[OK] found" in out
+        assert "[OK] Python (detected)" in out
+        assert "[WARN] not configured (default: disabled)" in out
+        # Both should be "not configured"
+        lines = [l for l in out.splitlines() if "not configured" in l]
+        assert len(lines) == 2
+
+    def test_project_section_non_python(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """No pyproject.toml shows [WARN] not found and (none detected)."""
+        symbols = {"success": "[OK]", "failure": "[ERR]", "warning": "[WARN]"}
+        _print_project_section(tmp_path, symbols)
+        out = capsys.readouterr().out
+        assert "[WARN] not found" in out
+        assert "(none detected)" in out
+        # Should NOT show [Python] subsection
+        assert "[Python]" not in out

--- a/tests/llm/formatting/test_stream_renderer.py
+++ b/tests/llm/formatting/test_stream_renderer.py
@@ -193,7 +193,7 @@ class TestRenderToolOutputRenderer:
         """Non-`result` keys render as extras below a blank separator."""
         data = {"result": "ok", "meta": "x"}
         lines, total = _render_tool_output(json.dumps(data))
-        assert lines == ["ok", "", 'meta: "x"']
+        assert lines == ["ok", "", "meta: x"]
         assert total == 3
 
     def test_result_dict_with_multiline_diff(self) -> None:
@@ -206,13 +206,13 @@ class TestRenderToolOutputRenderer:
     def test_no_text_unwrap(self) -> None:
         """`{"text": ...}` is not treated as an envelope — shown as key/value."""
         lines, total = _render_tool_output(json.dumps({"text": "hello"}))
-        assert lines == ['text: "hello"']
+        assert lines == ["text: hello"]
         assert total == 1
 
     def test_no_content_unwrap(self) -> None:
         """`{"content": ...}` is not treated as an envelope — shown as key/value."""
         lines, total = _render_tool_output(json.dumps({"content": "hello"}))
-        assert lines == ['content: "hello"']
+        assert lines == ["content: hello"]
         assert total == 1
 
     def test_full_mode_no_truncation(self) -> None:
@@ -422,7 +422,41 @@ class TestRenderOutputValue:
         assert result[1:] == [f"  {line}" for line in expected_inner]
 
     def test_string_value_in_dict(self) -> None:
-        assert _render_output_value({"key": "simple"}) == ['key: "simple"']
+        assert _render_output_value({"key": "simple"}) == ["key: simple"]
+
+    def test_string_value_no_json_escaping(self) -> None:
+        """String values in dicts render without JSON escaping (no double backslashes)."""
+        result = _render_output_value({"file_path": "C:\\Users\\test\\file.py"})
+        assert result == ["file_path: C:\\Users\\test\\file.py"]
+
+    def test_list_of_strings_plain(self) -> None:
+        """List of strings renders as plain lines, not JSON array."""
+        result = _render_output_value(["file_a.py", "file_b.py", "dir/file_c.py"])
+        assert result == ["file_a.py", "file_b.py", "dir/file_c.py"]
+
+    def test_list_of_strings_no_quotes_or_brackets(self) -> None:
+        """String list items have no JSON quotes, commas, or brackets."""
+        result = _render_output_value(["src\\main.py"])
+        assert result == ["src\\main.py"]
+        assert '"' not in result[0]
+        assert "[" not in result[0]
+
+    def test_mixed_list_still_uses_json(self) -> None:
+        """Lists with non-string items still use JSON formatting."""
+        result = _render_output_value([1, 2, 3])
+        assert result == ["[1, 2, 3]"]
+
+    def test_list_with_dicts_still_uses_json(self) -> None:
+        """Lists containing dicts still use JSON formatting."""
+        result = _render_output_value([{"a": 1}])
+        assert result == ['[{"a": 1}]']
+
+    def test_long_list_with_dicts_expanded(self) -> None:
+        """Long lists with dicts use expanded JSON formatting."""
+        value = [{"key": f"value_{i}"} for i in range(10)]
+        result = _render_output_value(value)
+        expected = json.dumps(value, indent=2).splitlines()
+        assert result == expected
 
 
 class TestFormatToolStart:

--- a/tests/llm/formatting/test_stream_renderer.py
+++ b/tests/llm/formatting/test_stream_renderer.py
@@ -434,13 +434,6 @@ class TestRenderOutputValue:
         result = _render_output_value(["file_a.py", "file_b.py", "dir/file_c.py"])
         assert result == ["file_a.py", "file_b.py", "dir/file_c.py"]
 
-    def test_list_of_strings_no_quotes_or_brackets(self) -> None:
-        """String list items have no JSON quotes, commas, or brackets."""
-        result = _render_output_value(["src\\main.py"])
-        assert result == ["src\\main.py"]
-        assert '"' not in result[0]
-        assert "[" not in result[0]
-
     def test_mixed_list_still_uses_json(self) -> None:
         """Lists with non-string items still use JSON formatting."""
         result = _render_output_value([1, 2, 3])

--- a/tests/test_pyproject_config.py
+++ b/tests/test_pyproject_config.py
@@ -17,3 +17,15 @@ def test_pyproject_install_from_github_config_exists() -> None:
 
     assert "packages-no-deps" in install_from_github
     assert isinstance(install_from_github["packages-no-deps"], list)
+
+
+def test_pyproject_implement_config_exists() -> None:
+    """Verify [tool.mcp-coder.implement] section exists with expected keys."""
+    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+    with open(pyproject_path, "rb") as f:
+        config = tomllib.load(f)
+
+    implement = config["tool"]["mcp-coder"]["implement"]
+
+    assert implement["format_code"] is True
+    assert implement["check_type_hints"] is True

--- a/tests/utils/test_pyproject_config.py
+++ b/tests/utils/test_pyproject_config.py
@@ -2,7 +2,10 @@
 
 from pathlib import Path
 
-from mcp_coder.utils.pyproject_config import get_github_install_config
+from mcp_coder.utils.pyproject_config import (
+    get_github_install_config,
+    get_implement_config,
+)
 
 
 class TestGetGithubInstallConfig:
@@ -50,3 +53,56 @@ packages-no-deps = []
         config = get_github_install_config(tmp_path)
         assert config.packages == []
         assert config.packages_no_deps == []
+
+
+class TestGetImplementConfig:
+    """Tests for get_implement_config."""
+
+    def test_returns_both_true_when_configured(self, tmp_path: Path) -> None:
+        """Both keys set to true are returned."""
+        (tmp_path / "pyproject.toml").write_text(
+            """\
+[tool.mcp-coder.implement]
+format_code = true
+check_type_hints = true
+""",
+            encoding="utf-8",
+        )
+        config = get_implement_config(tmp_path)
+        assert config.format_code is True
+        assert config.check_type_hints is True
+
+    def test_defaults_to_false_when_section_missing(self, tmp_path: Path) -> None:
+        """Missing [tool.mcp-coder.implement] returns False for both."""
+        (tmp_path / "pyproject.toml").write_text("[tool.mcp-coder]\n", encoding="utf-8")
+        config = get_implement_config(tmp_path)
+        assert config.format_code is False
+        assert config.check_type_hints is False
+
+    def test_defaults_to_false_when_file_missing(self, tmp_path: Path) -> None:
+        """No pyproject.toml returns False for both."""
+        config = get_implement_config(tmp_path)
+        assert config.format_code is False
+        assert config.check_type_hints is False
+
+    def test_partial_keys_default_missing_to_false(self, tmp_path: Path) -> None:
+        """Only format_code set, check_type_hints defaults to False."""
+        (tmp_path / "pyproject.toml").write_text(
+            """\
+[tool.mcp-coder.implement]
+format_code = true
+""",
+            encoding="utf-8",
+        )
+        config = get_implement_config(tmp_path)
+        assert config.format_code is True
+        assert config.check_type_hints is False
+
+    def test_handles_invalid_toml(self, tmp_path: Path) -> None:
+        """Malformed TOML file returns defaults."""
+        (tmp_path / "pyproject.toml").write_text(
+            "this is not valid toml {{{", encoding="utf-8"
+        )
+        config = get_implement_config(tmp_path)
+        assert config.format_code is False
+        assert config.check_type_hints is False

--- a/tests/workflows/implement/test_core.py
+++ b/tests/workflows/implement/test_core.py
@@ -1190,6 +1190,10 @@ class TestRunImplementWorkflow:
         # Verify process_task was called with None for execution_dir
         first_call_args = mock_process_task.call_args_list[0][0]
         assert first_call_args == (Path("/test/project"), "claude", None, None)
+        # Verify config booleans passed (defaults from missing pyproject.toml)
+        first_call_kwargs = mock_process_task.call_args_list[0][1]
+        assert first_call_kwargs["format_code"] is False
+        assert first_call_kwargs["check_type_hints"] is False
         assert mock_log_progress.call_count >= 2  # Initial + final progress
 
     @patch("mcp_coder.workflows.implement.core.check_git_clean")
@@ -1315,6 +1319,205 @@ class TestRunImplementWorkflow:
 
         assert result == 0  # Should succeed with no tasks
         mock_process_task.assert_called_once()
+
+    @patch("mcp_coder.workflows.implement.core.get_implement_config")
+    @patch("mcp_coder.workflows.implement.core.process_task_with_retry")
+    @patch("mcp_coder.workflows.implement.core.log_progress_summary")
+    @patch("mcp_coder.workflows.implement.core.prepare_task_tracker")
+    @patch("mcp_coder.workflows.implement.core.check_prerequisites")
+    @patch("mcp_coder.workflows.implement.core.check_main_branch")
+    @patch("mcp_coder.workflows.implement.core.check_git_clean")
+    def test_run_implement_workflow_reads_config(
+        self,
+        mock_check_git: MagicMock,
+        mock_check_branch: MagicMock,
+        mock_check_prereq: MagicMock,
+        mock_prepare_tracker: MagicMock,
+        mock_log_progress: MagicMock,
+        mock_process_task: MagicMock,
+        mock_get_config: MagicMock,
+    ) -> None:
+        """Test that get_implement_config is called with project_dir."""
+        mock_check_git.return_value = True
+        mock_check_branch.return_value = True
+        mock_check_prereq.return_value = True
+        mock_prepare_tracker.return_value = True
+        mock_process_task.return_value = (False, "no_tasks")
+
+        from mcp_coder.utils.pyproject_config import ImplementConfig
+
+        mock_get_config.return_value = ImplementConfig(
+            format_code=False, check_type_hints=False
+        )
+
+        run_implement_workflow(Path("/test/project"), "claude")
+
+        mock_get_config.assert_called_once_with(Path("/test/project"))
+
+    @patch("mcp_coder.workflows.implement.core.get_implement_config")
+    @patch("mcp_coder.workflows.implement.core.check_and_fix_ci", return_value=True)
+    @patch("mcp_coder.workflows.implement.core.run_finalisation", return_value=True)
+    @patch(
+        "mcp_coder.workflows.implement.core.get_full_status",
+        return_value={"staged": [], "modified": [], "untracked": []},
+    )
+    @patch("mcp_coder.workflows.implement.core.run_formatters", return_value=True)
+    @patch("mcp_coder.workflows.implement.core.check_and_fix_mypy", return_value=True)
+    @patch(
+        "mcp_coder.workflows.implement.core.prepare_llm_environment", return_value={}
+    )
+    @patch(
+        "mcp_coder.workflows.implement.core.get_current_branch_name",
+        return_value="feature/test-branch",
+    )
+    @patch("mcp_coder.workflows.implement.core.process_task_with_retry")
+    @patch("mcp_coder.workflows.implement.core.log_progress_summary")
+    @patch("mcp_coder.workflows.implement.core.prepare_task_tracker")
+    @patch("mcp_coder.workflows.implement.core.check_prerequisites")
+    @patch("mcp_coder.workflows.implement.core.check_main_branch")
+    @patch("mcp_coder.workflows.implement.core.check_git_clean")
+    def test_run_implement_workflow_passes_config_to_process_task(
+        self,
+        mock_check_git: MagicMock,
+        mock_check_branch: MagicMock,
+        mock_check_prereq: MagicMock,
+        mock_prepare_tracker: MagicMock,
+        mock_log_progress: MagicMock,
+        mock_process_task: MagicMock,
+        mock_get_branch: MagicMock,
+        mock_prepare_env: MagicMock,
+        mock_check_mypy: MagicMock,
+        mock_run_formatters: MagicMock,
+        mock_get_status: MagicMock,
+        _mock_run_finalisation: MagicMock,
+        mock_check_ci: MagicMock,
+        mock_get_config: MagicMock,
+    ) -> None:
+        """Test that config booleans are passed to process_task_with_retry."""
+        from mcp_coder.utils.pyproject_config import ImplementConfig
+
+        mock_get_config.return_value = ImplementConfig(
+            format_code=True, check_type_hints=True
+        )
+        mock_check_git.return_value = True
+        mock_check_branch.return_value = True
+        mock_check_prereq.return_value = True
+        mock_prepare_tracker.return_value = True
+        mock_process_task.side_effect = [(True, "completed"), (False, "no_tasks")]
+
+        run_implement_workflow(Path("/test/project"), "claude")
+
+        first_call_kwargs = mock_process_task.call_args_list[0][1]
+        assert first_call_kwargs["format_code"] is True
+        assert first_call_kwargs["check_type_hints"] is True
+
+    @patch("mcp_coder.workflows.implement.core.get_implement_config")
+    @patch("mcp_coder.workflows.implement.core.check_and_fix_ci", return_value=True)
+    @patch("mcp_coder.workflows.implement.core.run_finalisation", return_value=True)
+    @patch("mcp_coder.workflows.implement.core.check_and_fix_mypy", return_value=True)
+    @patch(
+        "mcp_coder.workflows.implement.core.prepare_llm_environment", return_value={}
+    )
+    @patch(
+        "mcp_coder.workflows.implement.core.get_current_branch_name",
+        return_value="feature/test-branch",
+    )
+    @patch("mcp_coder.workflows.implement.core.process_task_with_retry")
+    @patch("mcp_coder.workflows.implement.core.log_progress_summary")
+    @patch("mcp_coder.workflows.implement.core.prepare_task_tracker")
+    @patch("mcp_coder.workflows.implement.core.check_prerequisites")
+    @patch("mcp_coder.workflows.implement.core.check_main_branch")
+    @patch("mcp_coder.workflows.implement.core.check_git_clean")
+    def test_run_implement_workflow_skips_final_mypy_when_disabled(
+        self,
+        mock_check_git: MagicMock,
+        mock_check_branch: MagicMock,
+        mock_check_prereq: MagicMock,
+        mock_prepare_tracker: MagicMock,
+        mock_log_progress: MagicMock,
+        mock_process_task: MagicMock,
+        mock_get_branch: MagicMock,
+        mock_prepare_env: MagicMock,
+        mock_check_mypy: MagicMock,
+        _mock_run_finalisation: MagicMock,
+        mock_check_ci: MagicMock,
+        mock_get_config: MagicMock,
+    ) -> None:
+        """Test that check_type_hints=False skips final mypy in Step 5."""
+        from mcp_coder.utils.pyproject_config import ImplementConfig
+
+        mock_get_config.return_value = ImplementConfig(
+            format_code=True, check_type_hints=False
+        )
+        mock_check_git.return_value = True
+        mock_check_branch.return_value = True
+        mock_check_prereq.return_value = True
+        mock_prepare_tracker.return_value = True
+        mock_process_task.side_effect = [(True, "completed"), (False, "no_tasks")]
+
+        result = run_implement_workflow(Path("/test/project"), "claude")
+
+        assert result == 0
+        mock_check_mypy.assert_not_called()
+
+    @patch("mcp_coder.workflows.implement.core.get_implement_config")
+    @patch("mcp_coder.workflows.implement.core.check_and_fix_ci", return_value=True)
+    @patch("mcp_coder.workflows.implement.core.run_finalisation", return_value=True)
+    @patch(
+        "mcp_coder.workflows.implement.core.get_full_status",
+        return_value={"staged": [], "modified": [], "untracked": []},
+    )
+    @patch("mcp_coder.workflows.implement.core.run_formatters", return_value=True)
+    @patch("mcp_coder.workflows.implement.core.check_and_fix_mypy", return_value=True)
+    @patch(
+        "mcp_coder.workflows.implement.core.prepare_llm_environment", return_value={}
+    )
+    @patch(
+        "mcp_coder.workflows.implement.core.get_current_branch_name",
+        return_value="feature/test-branch",
+    )
+    @patch("mcp_coder.workflows.implement.core.process_task_with_retry")
+    @patch("mcp_coder.workflows.implement.core.log_progress_summary")
+    @patch("mcp_coder.workflows.implement.core.prepare_task_tracker")
+    @patch("mcp_coder.workflows.implement.core.check_prerequisites")
+    @patch("mcp_coder.workflows.implement.core.check_main_branch")
+    @patch("mcp_coder.workflows.implement.core.check_git_clean")
+    def test_run_implement_workflow_skips_final_formatting_when_disabled(
+        self,
+        mock_check_git: MagicMock,
+        mock_check_branch: MagicMock,
+        mock_check_prereq: MagicMock,
+        mock_prepare_tracker: MagicMock,
+        mock_log_progress: MagicMock,
+        mock_process_task: MagicMock,
+        mock_get_branch: MagicMock,
+        mock_prepare_env: MagicMock,
+        mock_check_mypy: MagicMock,
+        mock_run_formatters: MagicMock,
+        mock_get_status: MagicMock,
+        _mock_run_finalisation: MagicMock,
+        mock_check_ci: MagicMock,
+        mock_get_config: MagicMock,
+    ) -> None:
+        """Test that format_code=False skips formatters in Step 5 while mypy still runs."""
+        from mcp_coder.utils.pyproject_config import ImplementConfig
+
+        mock_get_config.return_value = ImplementConfig(
+            format_code=False, check_type_hints=True
+        )
+        mock_check_git.return_value = True
+        mock_check_branch.return_value = True
+        mock_check_prereq.return_value = True
+        mock_prepare_tracker.return_value = True
+        mock_process_task.side_effect = [(True, "completed"), (False, "no_tasks")]
+
+        result = run_implement_workflow(Path("/test/project"), "claude")
+
+        assert result == 0
+        # mypy should still be called since check_type_hints=True
+        mock_check_mypy.assert_called_once()
+        # but formatters should NOT be called since format_code=False
+        mock_run_formatters.assert_not_called()
 
 
 class TestIntegration:

--- a/tests/workflows/implement/test_task_processing.py
+++ b/tests/workflows/implement/test_task_processing.py
@@ -501,7 +501,12 @@ class TestProcessSingleTask:
         mock_commit.return_value = True
         mock_push.return_value = True
 
-        success, reason = process_single_task(Path("/test/project"), "claude")
+        success, reason = process_single_task(
+            Path("/test/project"),
+            "claude",
+            format_code=True,
+            check_type_hints=True,
+        )
 
         assert success is True
         assert reason == "completed"
@@ -680,7 +685,9 @@ class TestProcessSingleTask:
         mock_check_mypy.return_value = True
         mock_run_formatters.return_value = False
 
-        success, reason = process_single_task(Path("/test/project"), "claude")
+        success, reason = process_single_task(
+            Path("/test/project"), "claude", format_code=True, check_type_hints=True
+        )
 
         assert success is False
         assert reason == "error"
@@ -742,6 +749,201 @@ class TestProcessSingleTask:
         assert RETRY_REMINDER not in prompt_sent
 
 
+class TestProcessSingleTaskGating:
+    """Test format_code and check_type_hints gating in process_single_task."""
+
+    @patch("mcp_coder.workflows.implement.task_processing.push_changes")
+    @patch("mcp_coder.workflows.implement.task_processing.commit_changes")
+    @patch("mcp_coder.workflows.implement.task_processing.run_formatters")
+    @patch("mcp_coder.workflows.implement.task_processing.check_and_fix_mypy")
+    @patch("mcp_coder.workflows.implement.task_processing.get_full_status")
+    @patch("mcp_coder.workflows.implement.task_processing.store_session")
+    @patch("mcp_coder.workflows.implement.task_processing.prompt_llm")
+    @patch("mcp_coder.workflows.implement.task_processing.get_prompt")
+    @patch("mcp_coder.workflows.implement.task_processing.get_next_task")
+    def test_process_single_task_skips_formatters_when_format_code_false(
+        self,
+        mock_get_next_task: MagicMock,
+        mock_get_prompt: MagicMock,
+        mock_prompt_llm: MagicMock,
+        mock_store_session: MagicMock,
+        mock_get_status: MagicMock,
+        mock_check_mypy: MagicMock,
+        mock_run_formatters: MagicMock,
+        mock_commit: MagicMock,
+        mock_push: MagicMock,
+    ) -> None:
+        """Verify run_formatters not called when format_code=False."""
+        mock_get_next_task.return_value = "Step 1: Test task"
+        mock_get_prompt.return_value = "Template"
+        mock_prompt_llm.return_value = _make_llm_response("Response")
+        mock_get_status.return_value = {
+            "staged": ["file.py"],
+            "modified": [],
+            "untracked": [],
+        }
+        mock_commit.return_value = True
+        mock_push.return_value = True
+
+        success, reason = process_single_task(
+            Path("/test/project"), "claude", format_code=False
+        )
+
+        assert success is True
+        assert reason == "completed"
+        mock_run_formatters.assert_not_called()
+
+    @patch("mcp_coder.workflows.implement.task_processing.push_changes")
+    @patch("mcp_coder.workflows.implement.task_processing.commit_changes")
+    @patch("mcp_coder.workflows.implement.task_processing.run_formatters")
+    @patch("mcp_coder.workflows.implement.task_processing.check_and_fix_mypy")
+    @patch("mcp_coder.workflows.implement.task_processing.get_full_status")
+    @patch("mcp_coder.workflows.implement.task_processing.store_session")
+    @patch("mcp_coder.workflows.implement.task_processing.prompt_llm")
+    @patch("mcp_coder.workflows.implement.task_processing.get_prompt")
+    @patch("mcp_coder.workflows.implement.task_processing.get_next_task")
+    def test_process_single_task_runs_formatters_when_format_code_true(
+        self,
+        mock_get_next_task: MagicMock,
+        mock_get_prompt: MagicMock,
+        mock_prompt_llm: MagicMock,
+        mock_store_session: MagicMock,
+        mock_get_status: MagicMock,
+        mock_check_mypy: MagicMock,
+        mock_run_formatters: MagicMock,
+        mock_commit: MagicMock,
+        mock_push: MagicMock,
+    ) -> None:
+        """Verify run_formatters called when format_code=True."""
+        mock_get_next_task.return_value = "Step 1: Test task"
+        mock_get_prompt.return_value = "Template"
+        mock_prompt_llm.return_value = _make_llm_response("Response")
+        mock_get_status.return_value = {
+            "staged": ["file.py"],
+            "modified": [],
+            "untracked": [],
+        }
+        mock_run_formatters.return_value = True
+        mock_commit.return_value = True
+        mock_push.return_value = True
+
+        success, reason = process_single_task(
+            Path("/test/project"), "claude", format_code=True
+        )
+
+        assert success is True
+        assert reason == "completed"
+        mock_run_formatters.assert_called_once_with(Path("/test/project"))
+
+    @patch(
+        "mcp_coder.workflows.implement.task_processing.RUN_MYPY_AFTER_EACH_TASK", True
+    )
+    @patch("mcp_coder.workflows.implement.task_processing.push_changes")
+    @patch("mcp_coder.workflows.implement.task_processing.commit_changes")
+    @patch("mcp_coder.workflows.implement.task_processing.run_formatters")
+    @patch("mcp_coder.workflows.implement.task_processing.check_and_fix_mypy")
+    @patch("mcp_coder.workflows.implement.task_processing.get_full_status")
+    @patch("mcp_coder.workflows.implement.task_processing.store_session")
+    @patch("mcp_coder.workflows.implement.task_processing.prompt_llm")
+    @patch("mcp_coder.workflows.implement.task_processing.get_prompt")
+    @patch("mcp_coder.workflows.implement.task_processing.get_next_task")
+    def test_process_single_task_skips_mypy_when_check_type_hints_false(
+        self,
+        mock_get_next_task: MagicMock,
+        mock_get_prompt: MagicMock,
+        mock_prompt_llm: MagicMock,
+        mock_store_session: MagicMock,
+        mock_get_status: MagicMock,
+        mock_check_mypy: MagicMock,
+        mock_run_formatters: MagicMock,
+        mock_commit: MagicMock,
+        mock_push: MagicMock,
+    ) -> None:
+        """Verify check_and_fix_mypy not called when check_type_hints=False."""
+        mock_get_next_task.return_value = "Step 1: Test task"
+        mock_get_prompt.return_value = "Template"
+        mock_prompt_llm.return_value = _make_llm_response("Response")
+        mock_get_status.return_value = {
+            "staged": ["file.py"],
+            "modified": [],
+            "untracked": [],
+        }
+        mock_commit.return_value = True
+        mock_push.return_value = True
+
+        success, reason = process_single_task(
+            Path("/test/project"), "claude", check_type_hints=False
+        )
+
+        assert success is True
+        assert reason == "completed"
+        mock_check_mypy.assert_not_called()
+
+    @patch(
+        "mcp_coder.workflows.implement.task_processing.RUN_MYPY_AFTER_EACH_TASK", True
+    )
+    @patch("mcp_coder.workflows.implement.task_processing.push_changes")
+    @patch("mcp_coder.workflows.implement.task_processing.commit_changes")
+    @patch("mcp_coder.workflows.implement.task_processing.run_formatters")
+    @patch("mcp_coder.workflows.implement.task_processing.check_and_fix_mypy")
+    @patch("mcp_coder.workflows.implement.task_processing.get_full_status")
+    @patch("mcp_coder.workflows.implement.task_processing.store_session")
+    @patch("mcp_coder.workflows.implement.task_processing.prompt_llm")
+    @patch("mcp_coder.workflows.implement.task_processing.get_prompt")
+    @patch("mcp_coder.workflows.implement.task_processing.get_next_task")
+    def test_process_single_task_runs_mypy_when_check_type_hints_true(
+        self,
+        mock_get_next_task: MagicMock,
+        mock_get_prompt: MagicMock,
+        mock_prompt_llm: MagicMock,
+        mock_store_session: MagicMock,
+        mock_get_status: MagicMock,
+        mock_check_mypy: MagicMock,
+        mock_run_formatters: MagicMock,
+        mock_commit: MagicMock,
+        mock_push: MagicMock,
+    ) -> None:
+        """Verify check_and_fix_mypy called when check_type_hints=True."""
+        mock_get_next_task.return_value = "Step 1: Test task"
+        mock_get_prompt.return_value = "Template"
+        mock_prompt_llm.return_value = _make_llm_response("Response")
+        mock_get_status.return_value = {
+            "staged": ["file.py"],
+            "modified": [],
+            "untracked": [],
+        }
+        mock_check_mypy.return_value = True
+        mock_commit.return_value = True
+        mock_push.return_value = True
+
+        success, reason = process_single_task(
+            Path("/test/project"), "claude", check_type_hints=True
+        )
+
+        assert success is True
+        assert reason == "completed"
+        mock_check_mypy.assert_called_once()
+
+    @patch("mcp_coder.workflows.implement.task_processing.process_single_task")
+    def test_process_task_with_retry_forwards_config_params(
+        self, mock_process: MagicMock
+    ) -> None:
+        """Verify process_task_with_retry passes format_code and check_type_hints through."""
+        mock_process.return_value = (True, "completed")
+
+        process_task_with_retry(
+            Path("/test/project"),
+            "claude",
+            format_code=True,
+            check_type_hints=True,
+        )
+
+        mock_process.assert_called_once()
+        call_kwargs = mock_process.call_args
+        assert call_kwargs.kwargs["format_code"] is True
+        assert call_kwargs.kwargs["check_type_hints"] is True
+
+
 class TestIntegration:
     """Integration tests for task processing workflow."""
 
@@ -793,7 +995,9 @@ class TestIntegration:
         mock_push.return_value = True
 
         # Execute workflow
-        success, reason = process_single_task(project_dir, "claude")
+        success, reason = process_single_task(
+            project_dir, "claude", format_code=True, check_type_hints=True
+        )
 
         # Verify success
         assert success is True


### PR DESCRIPTION
## Summary
Makes code formatting and type-hint checking in the implement workflow configurable via `[tool.mcp-coder.implement]` in `pyproject.toml`, allowing projects to opt in/out of these steps.

## Changes
- Add `ImplementConfig` dataclass and `get_implement_config()` to read `format_code` and `check_type_hints` from pyproject.toml
- Gate `run_formatters` and `check_and_fix_mypy` calls in `core.py` and `task_processing.py` behind config booleans
- Add `_print_project_section` to `verify` command showing detected language and tool config status
- Fix `stream_renderer` to render plain strings without JSON escaping and string lists as plain lines
- Add comprehensive tests for config parsing, gating logic, verify output, and renderer changes