### PR TITLE
fix(claude.bat): reset terminal state after Claude exits

### DIFF
--- a/claude.bat
+++ b/claude.bat
@@ -90,3 +90,8 @@ echo   Project dir:  !MCP_CODER_PROJECT_DIR!
 echo   Venv dir:     !MCP_CODER_VENV_DIR!
 
 C:\Users\%USERNAME%\.local\bin\claude.exe %*
+
+REM Reset terminal state after Claude exits (workaround for dirty terminal bug)
+REM See https://github.com/anthropics/claude-code/issues/38761
+for /f %%a in ('echo prompt $E ^| cmd') do set "ESC=%%a"
+<nul set /p="!ESC![?2004l!ESC![?1l!ESC![?25h!ESC![J"


### PR DESCRIPTION
## Summary
- Add escape sequence cleanup after `claude.exe` returns to work around the dirty terminal bug (anthropics/claude-code#38761)
- Resets bracketed paste mode, cursor key mode, cursor visibility, and clears leftover escape sequences
- Ported from `mcp-coder-utils`

## Test plan
- [ ] Run `claude.bat` and exit — verify terminal renders correctly afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)