### PR TITLE
fix(vscodeclaude): batch newline breaks color prefix in startup scripts

### DIFF
--- a/src/mcp_coder/workflows/vscodeclaude/templates.py
+++ b/src/mcp_coder/workflows/vscodeclaude/templates.py
@@ -151,7 +151,20 @@ INTERACTIVE_ONLY_SECTION_WINDOWS = r"""echo.
 echo Running: {command} {issue_number}
 echo.
 
-claude "{color_prefix}{command} {issue_number}"
+claude "{command} {issue_number}"
+"""
+
+# Single-command flow with color (delayed expansion embeds newline in argument)
+INTERACTIVE_ONLY_WITH_COLOR_SECTION_WINDOWS = r"""echo.
+echo Running: {command} {issue_number}
+echo.
+
+setlocal EnableDelayedExpansion
+set LF=^
+
+
+claude "/color {color}!LF!{command} {issue_number}"
+endlocal
 """
 
 # Middle commands in multi-command flow for Windows (automated session resume)
@@ -177,7 +190,22 @@ echo You can now interact with Claude directly.
 echo The conversation context from previous steps is preserved.
 echo.
 
-claude --resume %SESSION_ID% "{color_prefix}{command}"
+claude --resume %SESSION_ID% "{command}"
+"""
+
+# Last command in multi-command flow with color
+INTERACTIVE_RESUME_WITH_COLOR_AND_COMMAND_WINDOWS = r"""echo.
+echo === Step {step_number}: Interactive Session ===
+echo You can now interact with Claude directly.
+echo The conversation context from previous steps is preserved.
+echo.
+
+setlocal EnableDelayedExpansion
+set LF=^
+
+
+claude --resume %SESSION_ID% "/color {color}!LF!{command}"
+endlocal
 """
 
 # Main startup script for Windows (with venv and mcp-coder)

--- a/src/mcp_coder/workflows/vscodeclaude/workspace.py
+++ b/src/mcp_coder/workflows/vscodeclaude/workspace.py
@@ -514,6 +514,8 @@ def create_startup_script(
         AUTOMATED_RESUME_SECTION_WINDOWS,
         AUTOMATED_SECTION_WINDOWS,
         INTERACTIVE_ONLY_SECTION_WINDOWS,
+        INTERACTIVE_ONLY_WITH_COLOR_SECTION_WINDOWS,
+        INTERACTIVE_RESUME_WITH_COLOR_AND_COMMAND_WINDOWS,
         INTERACTIVE_RESUME_WITH_COMMAND_WINDOWS,
         INTERVENTION_SCRIPT_WINDOWS,
         STARTUP_SCRIPT_WINDOWS,
@@ -527,9 +529,8 @@ def create_startup_script(
     commands = config.get("commands", []) if config else []
     emoji = config["emoji"] if config else "📋"
 
-    # Build color prefix for interactive templates
+    # Color for interactive templates (used to select color-aware template variant)
     color = config.get("color") if config else None
-    color_prefix = f"/color {color}\n" if color else ""
 
     # Default: use raw title (for non-Windows platforms when implemented)
     title_display = issue_title[:58] if len(issue_title) > 58 else issue_title
@@ -582,11 +583,19 @@ def create_startup_script(
             # Build command sections based on commands list
             if len(commands) == 1:
                 # Single command: interactive only, no step labels
-                command_sections = INTERACTIVE_ONLY_SECTION_WINDOWS.format(
-                    command=commands[0],
-                    issue_number=issue_number,
-                    color_prefix=color_prefix,
-                )
+                if color:
+                    command_sections = (
+                        INTERACTIVE_ONLY_WITH_COLOR_SECTION_WINDOWS.format(
+                            command=commands[0],
+                            issue_number=issue_number,
+                            color=color,
+                        )
+                    )
+                else:
+                    command_sections = INTERACTIVE_ONLY_SECTION_WINDOWS.format(
+                        command=commands[0],
+                        issue_number=issue_number,
+                    )
             elif len(commands) > 1:
                 sections = []
                 for i, cmd in enumerate(commands):
@@ -610,13 +619,21 @@ def create_startup_script(
                             )
                         )
                     if is_last:
-                        sections.append(
-                            INTERACTIVE_RESUME_WITH_COMMAND_WINDOWS.format(
-                                command=cmd,
-                                step_number=step_number,
-                                color_prefix=color_prefix,
+                        if color:
+                            sections.append(
+                                INTERACTIVE_RESUME_WITH_COLOR_AND_COMMAND_WINDOWS.format(
+                                    command=cmd,
+                                    step_number=step_number,
+                                    color=color,
+                                )
                             )
-                        )
+                        else:
+                            sections.append(
+                                INTERACTIVE_RESUME_WITH_COMMAND_WINDOWS.format(
+                                    command=cmd,
+                                    step_number=step_number,
+                                )
+                            )
                 command_sections = "\n".join(sections)
             else:
                 command_sections = ""

--- a/tests/workflows/vscodeclaude/test_templates.py
+++ b/tests/workflows/vscodeclaude/test_templates.py
@@ -4,6 +4,8 @@ from mcp_coder.workflows.vscodeclaude.templates import (
     AUTOMATED_RESUME_SECTION_WINDOWS,
     AUTOMATED_SECTION_WINDOWS,
     INTERACTIVE_ONLY_SECTION_WINDOWS,
+    INTERACTIVE_ONLY_WITH_COLOR_SECTION_WINDOWS,
+    INTERACTIVE_RESUME_WITH_COLOR_AND_COMMAND_WINDOWS,
     INTERACTIVE_RESUME_WITH_COMMAND_WINDOWS,
     VENV_SECTION_WINDOWS,
 )
@@ -154,18 +156,28 @@ def test_venv_section_sets_uv_git_shallow() -> None:
     ), "VENV_SECTION_WINDOWS should set UV_GIT_SHALLOW=0 for setuptools_scm"
 
 
-def test_interactive_only_section_has_color_prefix_placeholder() -> None:
-    """Test that INTERACTIVE_ONLY_SECTION_WINDOWS contains {color_prefix} placeholder."""
-    assert (
-        "{color_prefix}" in INTERACTIVE_ONLY_SECTION_WINDOWS
-    ), "INTERACTIVE_ONLY_SECTION_WINDOWS must contain '{color_prefix}' placeholder"
+def test_interactive_only_with_color_uses_delayed_expansion() -> None:
+    """Test that color template uses delayed expansion to embed newline in batch arg."""
+    assert "EnableDelayedExpansion" in INTERACTIVE_ONLY_WITH_COLOR_SECTION_WINDOWS
+    assert "{color}" in INTERACTIVE_ONLY_WITH_COLOR_SECTION_WINDOWS
+    assert "!LF!" in INTERACTIVE_ONLY_WITH_COLOR_SECTION_WINDOWS
 
 
-def test_interactive_resume_section_has_color_prefix_placeholder() -> None:
-    """Test that INTERACTIVE_RESUME_WITH_COMMAND_WINDOWS contains {color_prefix} placeholder."""
-    assert (
-        "{color_prefix}" in INTERACTIVE_RESUME_WITH_COMMAND_WINDOWS
-    ), "INTERACTIVE_RESUME_WITH_COMMAND_WINDOWS must contain '{color_prefix}' placeholder"
+def test_interactive_resume_with_color_uses_delayed_expansion() -> None:
+    """Test that color resume template uses delayed expansion to embed newline."""
+    assert "EnableDelayedExpansion" in INTERACTIVE_RESUME_WITH_COLOR_AND_COMMAND_WINDOWS
+    assert "{color}" in INTERACTIVE_RESUME_WITH_COLOR_AND_COMMAND_WINDOWS
+    assert "!LF!" in INTERACTIVE_RESUME_WITH_COLOR_AND_COMMAND_WINDOWS
+
+
+def test_interactive_only_section_has_no_color_prefix() -> None:
+    """Test that base INTERACTIVE_ONLY_SECTION_WINDOWS has no color logic."""
+    assert "/color" not in INTERACTIVE_ONLY_SECTION_WINDOWS
+
+
+def test_interactive_resume_section_has_no_color_prefix() -> None:
+    """Test that base INTERACTIVE_RESUME_WITH_COMMAND_WINDOWS has no color logic."""
+    assert "/color" not in INTERACTIVE_RESUME_WITH_COMMAND_WINDOWS
 
 
 def test_venv_section_runs_editable_install() -> None:

--- a/tests/workflows/vscodeclaude/test_workspace_startup_script.py
+++ b/tests/workflows/vscodeclaude/test_workspace_startup_script.py
@@ -92,10 +92,9 @@ class TestCreateStartupScript:
         )
 
         content = script_path.read_text(encoding="utf-8")
-        # Single command: interactive-only with issue number, no resume
-        assert (
-            'claude "/color yellow\n/implementation_review_supervisor 123"' in content
-        )
+        # Single command with color: uses delayed expansion for newline
+        assert "EnableDelayedExpansion" in content
+        assert "/color yellow!LF!/implementation_review_supervisor 123" in content
         # No automated step for single command
         assert "mcp-coder prompt" not in content
         # No step labels for single command
@@ -274,9 +273,9 @@ class TestCreateStartupScript:
         content = script_path.read_text(encoding="utf-8")
         # First command is automated
         assert "mcp-coder prompt" in content
-        # Last command is interactive resume with color prefix
+        # Last command is interactive resume with color via delayed expansion
         assert "claude --resume %SESSION_ID%" in content
-        assert "/color green\n/discuss" in content
+        assert "/color green!LF!/discuss" in content
         # Multi-command has step labels
         assert "Step 1" in content
 
@@ -306,10 +305,9 @@ class TestCreateStartupScript:
         content = script_path.read_text(encoding="utf-8")
         # No automated step for single command
         assert "mcp-coder prompt" not in content
-        # Interactive-only with issue number and color prefix
-        assert (
-            'claude "/color yellow\n/implementation_review_supervisor 123"' in content
-        )
+        # Interactive-only with color via delayed expansion
+        assert "EnableDelayedExpansion" in content
+        assert "/color yellow!LF!/implementation_review_supervisor 123" in content
         # No step labels
         assert "Step 1" not in content
         assert "Step 2" not in content


### PR DESCRIPTION
## Summary
- The `/color` prefix injected a literal newline into `.bat` files, causing `cmd.exe` to split the `claude` argument across two batch lines — only the color command reached Claude, the actual task command was silently dropped
- Uses `setlocal EnableDelayedExpansion` with `!LF!` to embed the newline at execution time (after cmd.exe line parsing), keeping the full argument intact
- Adds separate color-aware template variants (`INTERACTIVE_ONLY_WITH_COLOR_SECTION_WINDOWS`, `INTERACTIVE_RESUME_WITH_COLOR_AND_COMMAND_WINDOWS`) selected in `workspace.py` based on config

## Test plan
- [x] All 32 vscodeclaude tests pass (templates + workspace startup script)
- [x] Full unit test suite passes (3,884 tests)
- [x] Pylint clean, mypy clean (pre-existing unrelated issue only)
- [ ] Manual: launch a vscodeclaude session with `status-04:plan-review` and verify both `/color blue` and the command execute