### PR TITLE
chore: remove redundant Bash permissions covered by MCP tools

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,6 @@
     "allow": [
       "Bash(./tools/pycycle_check.sh:*)",
       "Bash(./tools/tach_check.sh:*)",
-      "Bash(find:*)",
       "Bash(gh issue list:*)",
       "Bash(gh issue view:*)",
       "Bash(gh pr view:*)",
@@ -14,8 +13,6 @@
       "Bash(mcp-coder check branch-status:*)",
       "Bash(mcp-coder check file-size:*)",
       "Bash(mcp-coder gh-tool:*)",
-      "Bash(python -m pytest:*)",
-      "Bash(ruff check:*)",
       "Bash(ruff rule:*)",
       "Bash(start docs/architecture/dependency_graph.html)",
       "Bash(tach check:*)",

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,6 @@
     "allow": [
       "Bash(./tools/pycycle_check.sh:*)",
       "Bash(./tools/tach_check.sh:*)",
-      "Bash(gh issue list:*)",
       "Bash(gh issue view:*)",
       "Bash(gh pr view:*)",
       "Bash(gh run view:*)",
@@ -13,7 +12,6 @@
       "Bash(mcp-coder check branch-status:*)",
       "Bash(mcp-coder check file-size:*)",
       "Bash(mcp-coder gh-tool:*)",
-      "Bash(ruff rule:*)",
       "Bash(start docs/architecture/dependency_graph.html)",
       "Bash(tach check:*)",
       "mcp__tools-py__find_references",

--- a/.claude/skills/rebase/SKILL.md
+++ b/.claude/skills/rebase/SKILL.md
@@ -38,9 +38,11 @@ allowed-tools:
   - mcp__workspace__move_file
 ---
 
-!`mcp__workspace__git_status`
-
 # Rebase Branch onto Base Branch
+
+## First Step
+
+Call `mcp__workspace__git_status` before doing anything else.
 
 Rebase the current feature branch onto its base branch and resolve conflicts.
 


### PR DESCRIPTION
## Summary

- Remove `find`, `python -m pytest`, `ruff check`, `ruff rule`, and `gh issue list` from Bash allow-list — all covered by MCP tools
- Fix rebase skill: replace unsupported `!` pre-flight MCP syntax with prose instruction to call `git_status` first

## Test plan

- [ ] Verify MCP tools still work for pytest, ruff, search, and git status
- [ ] Verify rebase skill triggers git_status call on invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)