### PR TITLE
chore: work through general chore list (#544)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ dist/
 .pytest_cache/
 .mypy_cache/
 .ruff_cache/
+.import_linter_cache/
+.grimp_cache/
 # /.mcp.json
 # .claude/settings.local.json
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -34,7 +34,9 @@
         "--reference-project",
         "name=p_coder-utils,path=${USERPROFILE}\\Documents\\GitHub\\mcp-coder-utils,url=https://github.com/MarcusJellinghaus/mcp-coder-utils",
         "--reference-project",
-        "name=p_tools,path=${USERPROFILE}\\Documents\\GitHub\\mcp-tools-py,url=https://github.com/MarcusJellinghaus/mcp-tools-py"
+        "name=p_tools,path=${USERPROFILE}\\Documents\\GitHub\\mcp-tools-py,url=https://github.com/MarcusJellinghaus/mcp-tools-py",
+        "--reference-project",
+        "name=p_tools_sql,path=${USERPROFILE}\\Documents\\GitHub\\mcp-tools-sql,url=https://github.com/MarcusJellinghaus/mcp-tools-sql"
       ],
       "env": {
         "PYTHONPATH": "${MCP_CODER_VENV_DIR}\\Lib\\"

--- a/claude_local.bat
+++ b/claude_local.bat
@@ -65,20 +65,8 @@ if "!VIRTUAL_ENV!"=="" (
 )
 
 REM === Step 4: Editable install verification ===
-set "EDITABLE_OK=0"
-for /f "delims=" %%L in ('pip show mcp-coder 2^>nul') do (
-    echo %%L | findstr /i /c:"Editable project location" >nul 2>&1
-    if !errorlevel! equ 0 (
-        echo %%L | findstr /i /c:"%CD%" >nul 2>&1
-        if !errorlevel! equ 0 set "EDITABLE_OK=1"
-    )
-    echo %%L | findstr /i /c:"Location:" >nul 2>&1
-    if !errorlevel! equ 0 (
-        echo %%L | findstr /i /c:"%CD%" >nul 2>&1
-        if !errorlevel! equ 0 set "EDITABLE_OK=1"
-    )
-)
-if "!EDITABLE_OK!"=="0" (
+"%CD%\.venv\Scripts\python.exe" -c "from importlib.metadata import distribution as D; u=D('mcp-coder').read_text('direct_url.json') or ''; exit(0 if 'dir_info' in u and 'editable' in u else 1)" 2>nul
+if !errorlevel! NEQ 0 (
     echo WARNING: mcp-coder does not appear to be editable-installed from %CD%
     echo   For development, run: pip install -e .
     echo   Continuing anyway...

--- a/icoder_local.bat
+++ b/icoder_local.bat
@@ -65,20 +65,8 @@ if "!VIRTUAL_ENV!"=="" (
 )
 
 REM === Step 4: Editable install verification ===
-set "EDITABLE_OK=0"
-for /f "delims=" %%L in ('pip show mcp-coder 2^>nul') do (
-    echo %%L | findstr /i /c:"Editable project location" >nul 2>&1
-    if !errorlevel! equ 0 (
-        echo %%L | findstr /i /c:"%CD%" >nul 2>&1
-        if !errorlevel! equ 0 set "EDITABLE_OK=1"
-    )
-    echo %%L | findstr /i /c:"Location:" >nul 2>&1
-    if !errorlevel! equ 0 (
-        echo %%L | findstr /i /c:"%CD%" >nul 2>&1
-        if !errorlevel! equ 0 set "EDITABLE_OK=1"
-    )
-)
-if "!EDITABLE_OK!"=="0" (
+"%CD%\.venv\Scripts\python.exe" -c "from importlib.metadata import distribution as D; u=D('mcp-coder').read_text('direct_url.json') or ''; exit(0 if 'dir_info' in u and 'editable' in u else 1)" 2>nul
+if !errorlevel! NEQ 0 (
     echo WARNING: mcp-coder does not appear to be editable-installed from %CD%
     echo   For development, run: pip install -e .
     echo   Continuing anyway...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -345,10 +345,10 @@ packages = [
     "mcp-coder-utils @ git+https://github.com/MarcusJellinghaus/mcp-coder-utils.git",
     "mcp-config-tool @ git+https://github.com/MarcusJellinghaus/mcp-config.git",
     "mcp-workspace @ git+https://github.com/MarcusJellinghaus/mcp-workspace.git",
+    "mcp-tools-py @ git+https://github.com/MarcusJellinghaus/mcp-tools-py.git",
 ]
 # Installed WITHOUT deps (depend on siblings — avoid downgrading)
 packages-no-deps = [
-    "mcp-tools-py @ git+https://github.com/MarcusJellinghaus/mcp-tools-py.git",
 ]
 
 [tool.mcp-coder.implement]


### PR DESCRIPTION
## Summary

- Add `mcp-tools-sql` as reference project in `.mcp.json`
- Add `.import_linter_cache/` and `.grimp_cache/` to `.gitignore`
- Simplify editable-install check in `claude_local.bat` and `icoder_local.bat` using `importlib.metadata` (matches mcp-workspace#134)
- Move `mcp-tools-py` from `packages-no-deps` to `packages` in `pyproject.toml` so external deps like `jedi` are installed

Also verified already-applied items: `actions/github-script` v8, old git tool permissions cleanup.

Resolves all mcp_coder-scoped items in #544.

## Test plan

- [ ] Verify CI passes (no Python code changes, config/bat only)
- [ ] Verify `claude_local.bat` still detects editable installs correctly
- [ ] Verify `mcp-tools-py` deps install correctly via `install-from-github`