### PR TITLE
chore(skills): migrate native tools to MCP equivalents

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## MCP Tools — mandatory
 
-Use MCP tools for **all** operations. Never use `Read`, `Write`, `Edit`, or `Bash` for tasks that have an MCP equivalent. If no MCP equivalent exists, use Bash. Check the tool mapping table below first.
+**Do NOT use native Claude Code file tools** (`Read`, `Write`, `Edit`, `Glob`, `Grep`, `Bash`) for any operation that has an MCP equivalent. Always use the `mcp__workspace__*` tools instead. This applies to all file reading, writing, editing, searching, listing, and git operations. If no MCP equivalent exists, use Bash. Check the tool mapping table below first.
 
 ### Tool mapping
 

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,6 @@
 {
   "permissions": {
     "allow": [
-      "Bash(./tools/pycycle_check.sh:*)",
-      "Bash(./tools/tach_check.sh:*)",
       "Bash(mcp-coder gh-tool:*)",
       "Bash(start docs/architecture/dependency_graph.html)",
       "Bash(tach check:*)",

--- a/.claude/skills/commit_push/SKILL.md
+++ b/.claude/skills/commit_push/SKILL.md
@@ -7,9 +7,9 @@ allowed-tools:
   - "Bash(git commit *)"
   - "Bash(git push *)"
   - mcp__tools-py__run_format_code
-  - Read
-  - Glob
-  - Grep
+  - mcp__workspace__read_file
+  - mcp__workspace__list_directory
+  - mcp__workspace__search_files
 ---
 
 # Commit and Push Changes

--- a/.claude/skills/implementation_review/SKILL.md
+++ b/.claude/skills/implementation_review/SKILL.md
@@ -6,8 +6,7 @@ allowed-tools:
   - mcp__workspace__check_branch_status
   - mcp__workspace__read_file
   - mcp__workspace__list_directory
-  - Glob
-  - Grep
+  - mcp__workspace__search_files
 ---
 
 # Implementation Review (Code Review)

--- a/.claude/skills/implementation_review_supervisor/SKILL.md
+++ b/.claude/skills/implementation_review_supervisor/SKILL.md
@@ -73,6 +73,6 @@ You are a technical lead supervising a software engineer (subagent). You do not 
 **Status**: {committed / no changes needed}
 ```
 
-**Subagent instructions:** Remind subagents to follow CLAUDE.md (MCP tools, no `cd` prefix, approved commands only).
+**Subagent instructions:** When launching subagents, instruct them to follow CLAUDE.md — especially the MCP tool requirements (use `mcp__workspace__*` tools, not native file tools). Also remind them: no `cd` prefix, approved commands only.
 
 **Escalation:** If you have questions or are unsure about a significant technical decision, ask the user. For borderline Accept/Skip findings, default to better code quality rather than asking — only escalate when the fix has meaningful scope or risk, not for trivial changes in either direction. Import contract or architecture violations (from `run_lint_imports_check`): escalate to the user — fixes may require moving code between layers.

--- a/.claude/skills/issue_analyse/SKILL.md
+++ b/.claude/skills/issue_analyse/SKILL.md
@@ -7,6 +7,7 @@ allowed-tools:
   - mcp__workspace__git
   - mcp__workspace__read_file
   - mcp__workspace__list_directory
+  - mcp__tools-py__sleep
 ---
 
 # Analyse GitHub Issue
@@ -20,8 +21,9 @@ If no issue number is provided:
 1. Read `.vscodeclaude_status.txt` and extract the issue number from the `Issue #NNN` line
 2. If the file doesn't exist or has no issue number, ask the user
 
-Fetch the issue:
-Call `mcp__workspace__github_issue_view` with the issue number.
+Wait one second using `mcp__tools-py__sleep` with `seconds: 1`
+
+Fetch the issue using `mcp__workspace__github_issue_view`.
 
 ## Instructions
 

--- a/.claude/skills/issue_analyse_supervisor/SKILL.md
+++ b/.claude/skills/issue_analyse_supervisor/SKILL.md
@@ -64,7 +64,7 @@ You are a technical lead supervising a software engineer (subagent). You do not 
 **Status**: {continuing / no new questions}
 ```
 
-**Subagent instructions:** Remind subagents to follow CLAUDE.md (MCP tools, no `cd` prefix, approved commands only).
+**Subagent instructions:** When launching subagents, instruct them to follow CLAUDE.md — especially the MCP tool requirements (use `mcp__workspace__*` tools, not native file tools). Also remind them: no `cd` prefix, approved commands only.
 
 **Triage Guidelines:**
 

--- a/.claude/skills/issue_update/SKILL.md
+++ b/.claude/skills/issue_update/SKILL.md
@@ -7,9 +7,9 @@ allowed-tools:
   - mcp__workspace__github_issue_view
   - mcp__workspace__save_file
   - mcp__workspace__delete_this_file
-  - Read
-  - Glob
-  - Grep
+  - mcp__workspace__read_file
+  - mcp__workspace__list_directory
+  - mcp__workspace__search_files
 ---
 
 # Update GitHub Issue

--- a/.claude/skills/plan_review/SKILL.md
+++ b/.claude/skills/plan_review/SKILL.md
@@ -5,8 +5,7 @@ allowed-tools:
   - mcp__workspace__git
   - mcp__workspace__read_file
   - mcp__workspace__list_directory
-  - Glob
-  - Grep
+  - mcp__workspace__search_files
 ---
 
 # Review Implementation Plan

--- a/.claude/skills/plan_review_supervisor/SKILL.md
+++ b/.claude/skills/plan_review_supervisor/SKILL.md
@@ -65,7 +65,7 @@ You are a technical lead supervising a software engineer (subagent). You do not 
 **Status**: {committed / no changes needed}
 ```
 
-**Subagent instructions:** Remind subagents to follow CLAUDE.md (MCP tools, no `cd` prefix, approved commands only).
+**Subagent instructions:** When launching subagents, instruct them to follow CLAUDE.md — especially the MCP tool requirements (use `mcp__workspace__*` tools, not native file tools). Also remind them: no `cd` prefix, approved commands only.
 
 **Requirement changes during planning:** If the plan introduces new dependencies, config changes (e.g., `pyproject.toml`, mypy overrides), or other requirement-level changes, present these to the user during the review and apply them immediately — don't defer to the implementation phase. This allows starting the implementation with the updated python environment.
 


### PR DESCRIPTION
## Summary
- Replace native Claude Code tools (`Read`, `Glob`, `Grep`) with `mcp__workspace__*` equivalents in `commit_push`, `implementation_review`, `issue_update`, and `plan_review` skills
- Remove stale `pycycle_check.sh` and `tach_check.sh` Bash permissions from `settings.local.json`
- Strengthen native tool prohibition in `CLAUDE.md` to explicitly list all 6 native tools
- Add `mcp__tools-py__sleep` to `issue_analyse` skill with a wait step before fetching issues
- Update subagent instructions in all 3 supervisor skills to explicitly instruct about MCP tool requirements

## Test plan
- [ ] Verify skills load correctly (no YAML parse errors in frontmatter)
- [ ] Run `/issue_analyse` and confirm the sleep + fetch flow works
- [ ] Run `/commit_push` and confirm MCP tools are available
- [ ] Verify supervisor skills pass MCP instructions to subagents

Part of #544