### PR TITLE
fix: update shims for mcp-workspace breaking changes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -60,13 +60,13 @@ All checks must pass before proceeding.
 
 ```python
 # Fast unit tests (recommended)
-mcp__tools-py__run_pytest_check(extra_args=["-n", "auto", "-m", "not git_integration and not claude_cli_integration and not claude_api_integration and not copilot_cli_integration and not formatter_integration and not github_integration and not langchain_integration and not llm_integration and not textual_integration"])
+mcp__tools-py__run_pytest_check(extra_args=["-n", "auto", "-m", "not git_integration and not claude_cli_integration and not claude_api_integration and not copilot_cli_integration and not formatter_integration and not github_integration and not jenkins_integration and not langchain_integration and not llm_integration and not textual_integration"])
 
 # Specific integration tests
 mcp__tools-py__run_pytest_check(extra_args=["-n", "auto"], markers=["git_integration"])
 ```
 
-Markers: `git_integration`, `claude_api_integration`, `claude_cli_integration`, `copilot_cli_integration`, `formatter_integration`, `github_integration`, `langchain_integration`, `llm_integration`, `textual_integration`.
+Markers: `git_integration`, `claude_api_integration`, `claude_cli_integration`, `copilot_cli_integration`, `formatter_integration`, `github_integration`, `jenkins_integration`, `langchain_integration`, `llm_integration`, `textual_integration`.
 
 When debugging test failures, add `"-v", "-s", "--tb=short"` to extra_args.
 

--- a/.github/workflows/langchain-integration.yml
+++ b/.github/workflows/langchain-integration.yml
@@ -47,8 +47,11 @@ jobs:
         with:
           python-version: 3.11
 
-      - name: Install latest mcp-tools-py from GitHub
-        run: uv pip install --system "mcp-tools-py @ git+https://github.com/MarcusJellinghaus/mcp-tools-py.git"
+      - name: Install latest GitHub dependencies
+        run: |
+          uv pip install --system "mcp-coder-utils @ git+https://github.com/MarcusJellinghaus/mcp-coder-utils.git"
+          uv pip install --system "mcp-workspace @ git+https://github.com/MarcusJellinghaus/mcp-workspace.git"
+          uv pip install --system --no-deps "mcp-tools-py @ git+https://github.com/MarcusJellinghaus/mcp-tools-py.git"
 
       - name: Install dependencies
         run: uv pip install --system ".[dev,langchain]"

--- a/src/mcp_coder/cli/commands/coordinator/core.py
+++ b/src/mcp_coder/cli/commands/coordinator/core.py
@@ -15,8 +15,8 @@ from ....mcp_workspace_github import (
     IssueBranchManager,
     IssueData,
     IssueManager,
+    RepoIdentifier,
     get_all_cached_issues,
-    parse_github_url,
 )
 from ....utils.jenkins_operations.client import JenkinsClient
 from ....utils.user_config import get_config_file_path, get_config_values
@@ -400,14 +400,15 @@ def dispatch_workflow(
         branch_name = "main"
     else:  # from_issue
         # Parse repo URL to extract owner and name for branch resolution
-        parsed_url = parse_github_url(repo_config["repo_url"])
-        if not parsed_url:
+        try:
+            repo_id = RepoIdentifier.from_repo_url(repo_config["repo_url"])
+        except ValueError:
             logger.error(
                 f"Invalid GitHub URL in repo config: {repo_config['repo_url']}"
             )
             return
 
-        repo_owner, repo_name = parsed_url
+        repo_owner, repo_name = repo_id.owner, repo_id.repo_name
 
         # Resolve branch with PR fallback (checks linkedBranches then draft/open PRs)
         resolved_branch = branch_manager.get_branch_with_pr_fallback(

--- a/src/mcp_coder/cli/commands/coordinator/issue_stats.py
+++ b/src/mcp_coder/cli/commands/coordinator/issue_stats.py
@@ -11,7 +11,7 @@ import argparse
 import logging
 from typing import Any
 
-from mcp_coder.mcp_workspace_git import get_github_repository_url
+from mcp_coder.mcp_workspace_git import get_repository_identifier
 
 from ....config.label_config import (
     get_labels_config_path,
@@ -298,11 +298,12 @@ def execute_coordinator_issue_stats(args: argparse.Namespace) -> int:
         logger.info(f"Project directory: {project_dir}")
 
         # Get repository URL from git remote
-        repo_url = get_github_repository_url(project_dir)
-        if not repo_url:
+        identifier = get_repository_identifier(project_dir)
+        if not identifier:
             raise ValueError(
                 "Could not determine GitHub repository URL from git remote"
             )
+        repo_url = identifier.https_url
         logger.info(f"Repository URL: {repo_url}")
 
         # Load labels configuration

--- a/src/mcp_coder/cli/utils.py
+++ b/src/mcp_coder/cli/utils.py
@@ -9,7 +9,7 @@ import logging
 import os
 from pathlib import Path
 
-from mcp_coder.mcp_workspace_git import get_github_repository_url
+from mcp_coder.mcp_workspace_git import get_repository_identifier
 
 from ..llm.session import parse_llm_method
 from ..llm.types import SUPPORTED_PROVIDERS
@@ -79,7 +79,8 @@ def resolve_issue_interaction_flags(
     # Get config values (default False)
     cfg_labels = False
     cfg_comments = False
-    repo_url = get_github_repository_url(project_dir)
+    identifier = get_repository_identifier(project_dir)
+    repo_url = identifier.https_url if identifier else None
     if repo_url:
         section = find_repo_section_by_url(repo_url)
         if section:

--- a/src/mcp_coder/mcp_workspace_git.py
+++ b/src/mcp_coder/mcp_workspace_git.py
@@ -51,7 +51,7 @@ from mcp_workspace.git_operations.parent_branch_detection import (
 # Remotes
 from mcp_workspace.git_operations.remotes import (
     fetch_remote,
-    get_github_repository_url,
+    get_repository_identifier,
     git_push,
     push_branch,
     rebase_onto_branch,
@@ -90,7 +90,7 @@ __all__ = [
     "get_git_diff_for_commit",
     "get_compact_diff",
     "fetch_remote",
-    "get_github_repository_url",
+    "get_repository_identifier",
     "git_push",
     "push_branch",
     "rebase_onto_branch",

--- a/src/mcp_coder/mcp_workspace_github.py
+++ b/src/mcp_coder/mcp_workspace_github.py
@@ -9,6 +9,7 @@ from typing import List
 # Top-level package exports
 from mcp_workspace.github_operations import (
     BaseGitHubManager,
+    CheckResult,
     CIResultsManager,
     CIStatusData,
     LabelData,
@@ -16,18 +17,12 @@ from mcp_workspace.github_operations import (
     PullRequestManager,
     RepoIdentifier,
     get_authenticated_username,
+    verify_github,
 )
 
 # CI results submodule (TypedDicts + helpers)
 from mcp_workspace.github_operations.ci_results_manager import (
     JobData,
-)
-
-# GitHub utils submodule
-from mcp_workspace.github_operations.github_utils import (
-    format_github_https_url,
-    get_repo_full_name,
-    parse_github_url,
 )
 
 # Issues subpackage
@@ -55,6 +50,9 @@ __all__: List[str] = [
     # Base manager
     "BaseGitHubManager",
     "get_authenticated_username",
+    # Verification
+    "CheckResult",
+    "verify_github",
     # CI results
     "CIResultsManager",
     "CIStatusData",
@@ -67,9 +65,6 @@ __all__: List[str] = [
     "PullRequestData",
     # Repository
     "RepoIdentifier",
-    "parse_github_url",
-    "format_github_https_url",
-    "get_repo_full_name",
     # Issues
     "IssueManager",
     "IssueBranchManager",

--- a/src/mcp_coder/workflow_utils/label_transitions.py
+++ b/src/mcp_coder/workflow_utils/label_transitions.py
@@ -92,8 +92,8 @@ def update_workflow_label(
 
             # Step 3: Verify branch is linked to the issue
             repo_url = None
-            if issue_manager._repo_full_name is not None:
-                repo_url = f"https://github.com/{issue_manager._repo_full_name}.git"
+            if issue_manager._cached_repo_identifier is not None:
+                repo_url = issue_manager._cached_repo_identifier.https_url
 
             # IssueBranchManager.__init__ doesn't accept github_token,
             # so init via BaseGitHubManager to reuse the existing token.

--- a/tests/cli/commands/coordinator/test_core.py
+++ b/tests/cli/commands/coordinator/test_core.py
@@ -549,9 +549,9 @@ class TestDispatchWorkflow:
         assert "git pull" in command
         assert "mcp-coder --log-level INFO create-plan 123" in command
 
-    @patch("mcp_coder.cli.commands.coordinator.core.parse_github_url")
+    @patch("mcp_coder.cli.commands.coordinator.core.RepoIdentifier")
     def test_dispatch_workflow_handles_missing_branch_gracefully(
-        self, mock_parse_url: MagicMock, caplog: pytest.LogCaptureFixture
+        self, mock_repo_id_cls: MagicMock, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Test that dispatch_workflow logs error and returns early when no branch found."""
         # Setup - Mock issue with status-08:ready-pr label (requires branch)
@@ -582,8 +582,9 @@ class TestDispatchWorkflow:
         mock_issue_mgr = MagicMock()
         mock_branch_mgr = MagicMock()
 
-        # Mock parse_github_url to return owner and repo
-        mock_parse_url.return_value = ("test", "repo")
+        # Mock RepoIdentifier.from_repo_url to return identifier with owner and repo
+        mock_repo_id = MagicMock(owner="test", repo_name="repo")
+        mock_repo_id_cls.from_repo_url.return_value = mock_repo_id
 
         # Mock get_branch_with_pr_fallback to return None (missing branch scenario)
         mock_branch_mgr.get_branch_with_pr_fallback.return_value = None
@@ -602,8 +603,10 @@ class TestDispatchWorkflow:
             log_level="INFO",
         )
 
-        # Verify parse_github_url was called
-        mock_parse_url.assert_called_once_with("https://github.com/test/repo.git")
+        # Verify RepoIdentifier.from_repo_url was called
+        mock_repo_id_cls.from_repo_url.assert_called_once_with(
+            "https://github.com/test/repo.git"
+        )
 
         # Verify branch manager was called with correct parameters
         mock_branch_mgr.get_branch_with_pr_fallback.assert_called_once_with(
@@ -620,9 +623,9 @@ class TestDispatchWorkflow:
         mock_issue_mgr.remove_labels.assert_not_called()
         mock_issue_mgr.add_labels.assert_not_called()
 
-    @patch("mcp_coder.cli.commands.coordinator.core.parse_github_url")
+    @patch("mcp_coder.cli.commands.coordinator.core.RepoIdentifier")
     def test_dispatch_workflow_preserves_existing_behavior_with_valid_branch(
-        self, mock_parse_url: MagicMock
+        self, mock_repo_id_cls: MagicMock
     ) -> None:
         """Test that existing functionality works unchanged when branch exists."""
         # Setup - Mock issue with status-05:plan-ready label (requires branch)
@@ -653,8 +656,9 @@ class TestDispatchWorkflow:
         mock_issue_mgr = MagicMock()
         mock_branch_mgr = MagicMock()
 
-        # Mock parse_github_url to return owner and repo
-        mock_parse_url.return_value = ("test", "repo")
+        # Mock RepoIdentifier.from_repo_url to return identifier with owner and repo
+        mock_repo_id = MagicMock(owner="test", repo_name="repo")
+        mock_repo_id_cls.from_repo_url.return_value = mock_repo_id
 
         # Mock get_branch_with_pr_fallback to return valid branch
         mock_branch_mgr.get_branch_with_pr_fallback.return_value = "feature/issue-123"
@@ -675,8 +679,10 @@ class TestDispatchWorkflow:
             log_level="INFO",
         )
 
-        # Verify parse_github_url was called
-        mock_parse_url.assert_called_once_with("https://github.com/test/repo.git")
+        # Verify RepoIdentifier.from_repo_url was called
+        mock_repo_id_cls.from_repo_url.assert_called_once_with(
+            "https://github.com/test/repo.git"
+        )
 
         # Verify branch manager was called with correct parameters
         mock_branch_mgr.get_branch_with_pr_fallback.assert_called_once_with(

--- a/tests/cli/commands/coordinator/test_issue_stats_cli.py
+++ b/tests/cli/commands/coordinator/test_issue_stats_cli.py
@@ -8,7 +8,7 @@ Tests cover:
 import argparse
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -156,8 +156,8 @@ class TestExecuteCoordinatorIssueStats:
         # Mock the dependencies
         with (
             patch(
-                "mcp_coder.cli.commands.coordinator.issue_stats.get_github_repository_url"
-            ) as mock_get_url,
+                "mcp_coder.cli.commands.coordinator.issue_stats.get_repository_identifier"
+            ) as mock_get_id,
             patch(
                 "mcp_coder.cli.commands.coordinator.issue_stats.get_labels_config_path"
             ) as mock_config_path,
@@ -168,7 +168,9 @@ class TestExecuteCoordinatorIssueStats:
                 "mcp_coder.cli.commands.coordinator.issue_stats.IssueManager"
             ) as mock_issue_manager,
         ):
-            mock_get_url.return_value = "https://github.com/owner/repo"
+            mock_get_id.return_value = MagicMock(
+                https_url="https://github.com/owner/repo"
+            )
             mock_config_path.return_value = Path("/fake/labels.json")
             mock_load_config.return_value = test_labels_config
             mock_issue_manager.return_value.list_issues.return_value = []
@@ -214,8 +216,8 @@ class TestExecuteCoordinatorIssueStats:
 
         with (
             patch(
-                "mcp_coder.cli.commands.coordinator.issue_stats.get_github_repository_url"
-            ) as mock_get_url,
+                "mcp_coder.cli.commands.coordinator.issue_stats.get_repository_identifier"
+            ) as mock_get_id,
             patch(
                 "mcp_coder.cli.commands.coordinator.issue_stats.get_labels_config_path"
             ) as mock_config_path,
@@ -229,7 +231,9 @@ class TestExecuteCoordinatorIssueStats:
                 "mcp_coder.cli.commands.coordinator.issue_stats.display_statistics"
             ) as mock_display,
         ):
-            mock_get_url.return_value = "https://github.com/owner/repo"
+            mock_get_id.return_value = MagicMock(
+                https_url="https://github.com/owner/repo"
+            )
             mock_config_path.return_value = Path("/fake/labels.json")
             mock_load_config.return_value = test_labels_config
             mock_issue_manager.return_value.list_issues.return_value = []
@@ -261,8 +265,8 @@ class TestExecuteCoordinatorIssueStats:
 
         with (
             patch(
-                "mcp_coder.cli.commands.coordinator.issue_stats.get_github_repository_url"
-            ) as mock_get_url,
+                "mcp_coder.cli.commands.coordinator.issue_stats.get_repository_identifier"
+            ) as mock_get_id,
             patch(
                 "mcp_coder.cli.commands.coordinator.issue_stats.get_labels_config_path"
             ) as mock_config_path,
@@ -276,7 +280,9 @@ class TestExecuteCoordinatorIssueStats:
                 "mcp_coder.cli.commands.coordinator.issue_stats.display_statistics"
             ) as mock_display,
         ):
-            mock_get_url.return_value = "https://github.com/owner/repo"
+            mock_get_id.return_value = MagicMock(
+                https_url="https://github.com/owner/repo"
+            )
             mock_config_path.return_value = Path("/fake/labels.json")
             mock_load_config.return_value = test_labels_config
             mock_issue_manager.return_value.list_issues.return_value = []

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -436,7 +436,7 @@ class TestResolveExecutionDir:
 class TestResolveIssueInteractionFlags:
     """Test cases for resolve_issue_interaction_flags function."""
 
-    @patch("mcp_coder.cli.utils.get_github_repository_url", return_value=None)
+    @patch("mcp_coder.cli.utils.get_repository_identifier", return_value=None)
     def test_defaults_to_false_false_when_no_cli_no_config(
         self, _mock_git_url: MagicMock
     ) -> None:
@@ -455,8 +455,8 @@ class TestResolveIssueInteractionFlags:
         return_value="coordinator.repos.myrepo",
     )
     @patch(
-        "mcp_coder.cli.utils.get_github_repository_url",
-        return_value="https://github.com/org/repo",
+        "mcp_coder.cli.utils.get_repository_identifier",
+        return_value=MagicMock(https_url="https://github.com/org/repo"),
     )
     def test_cli_flags_override_config(
         self,
@@ -483,8 +483,8 @@ class TestResolveIssueInteractionFlags:
         return_value="coordinator.repos.myrepo",
     )
     @patch(
-        "mcp_coder.cli.utils.get_github_repository_url",
-        return_value="https://github.com/org/repo",
+        "mcp_coder.cli.utils.get_repository_identifier",
+        return_value=MagicMock(https_url="https://github.com/org/repo"),
     )
     def test_config_values_used_when_cli_none(
         self,
@@ -511,8 +511,8 @@ class TestResolveIssueInteractionFlags:
         return_value="coordinator.repos.myrepo",
     )
     @patch(
-        "mcp_coder.cli.utils.get_github_repository_url",
-        return_value="https://github.com/org/repo",
+        "mcp_coder.cli.utils.get_repository_identifier",
+        return_value=MagicMock(https_url="https://github.com/org/repo"),
     )
     def test_cli_true_overrides_config_false(
         self,
@@ -533,11 +533,11 @@ class TestResolveIssueInteractionFlags:
         result = resolve_issue_interaction_flags(args, Path("/tmp/project"))
         assert result == (True, True)
 
-    @patch("mcp_coder.cli.utils.get_github_repository_url", return_value=None)
+    @patch("mcp_coder.cli.utils.get_repository_identifier", return_value=None)
     def test_no_git_remote_falls_back_to_defaults(
         self, _mock_git_url: MagicMock
     ) -> None:
-        """get_github_repository_url returns None -> (False, False)."""
+        """get_repository_identifier returns None -> (False, False)."""
         args = MagicMock(
             spec=["update_issue_labels", "post_issue_comments"],
             update_issue_labels=None,
@@ -548,8 +548,8 @@ class TestResolveIssueInteractionFlags:
 
     @patch("mcp_coder.cli.utils.find_repo_section_by_url", return_value=None)
     @patch(
-        "mcp_coder.cli.utils.get_github_repository_url",
-        return_value="https://github.com/org/unknown-repo",
+        "mcp_coder.cli.utils.get_repository_identifier",
+        return_value=MagicMock(https_url="https://github.com/org/unknown-repo"),
     )
     def test_no_matching_repo_section_falls_back_to_defaults(
         self, _mock_git_url: MagicMock, mock_find: MagicMock
@@ -569,8 +569,8 @@ class TestResolveIssueInteractionFlags:
         return_value="coordinator.repos.myrepo",
     )
     @patch(
-        "mcp_coder.cli.utils.get_github_repository_url",
-        return_value="https://github.com/org/repo",
+        "mcp_coder.cli.utils.get_repository_identifier",
+        return_value=MagicMock(https_url="https://github.com/org/repo"),
     )
     def test_partial_cli_override(
         self,

--- a/tests/test_mcp_workspace_github_smoke.py
+++ b/tests/test_mcp_workspace_github_smoke.py
@@ -10,13 +10,14 @@ def test_all_exports_defined() -> None:
     """__all__ has expected count."""
     from mcp_coder.mcp_workspace_github import __all__
 
-    assert len(__all__) == 25
+    assert len(__all__) == 24
 
 
 def test_key_symbols_importable() -> None:
     """Key symbols can be imported and are real implementations."""
     from mcp_coder.mcp_workspace_github import (
         BaseGitHubManager,
+        CheckResult,
         CIResultsManager,
         IssueManager,
         LabelsManager,
@@ -24,12 +25,13 @@ def test_key_symbols_importable() -> None:
         PullRequestManager,
         RepoIdentifier,
         get_authenticated_username,
-        parse_github_url,
+        verify_github,
     )
 
     assert callable(get_authenticated_username)
-    assert callable(parse_github_url)
+    assert callable(verify_github)
     assert BaseGitHubManager is not None
+    assert CheckResult is not None
     assert CIResultsManager is not None
     assert IssueManager is not None
     assert LabelsManager is not None

--- a/tests/test_module_integration.py
+++ b/tests/test_module_integration.py
@@ -119,7 +119,7 @@ class TestModuleIntegration:
             "get_default_branch_name",
             "get_full_status",
             "get_git_diff_for_commit",
-            "get_github_repository_url",
+            "get_repository_identifier",
             "git_push",
             "is_working_directory_clean",
             "stage_all_changes",

--- a/tests/workflow_utils/test_label_transitions.py
+++ b/tests/workflow_utils/test_label_transitions.py
@@ -73,16 +73,10 @@ def mock_github() -> Mock:
 
 @pytest.fixture
 def _mock_git_repo() -> Any:
-    """Mock _init_with_project_dir to avoid git repository checks."""
-
-    def _fake_init(self: Any, project_dir: Any) -> None:
-        self.project_dir = project_dir
-        self._repo_full_name = None  # pylint: disable=protected-access
-
-    with patch.object(
-        BaseGitHubManager,
-        "_init_with_project_dir",
-        _fake_init,
+    """Mock git repository check to avoid real I/O."""
+    with patch(
+        "mcp_workspace.git_operations.is_git_repository",
+        return_value=True,
     ):
         yield
 

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -38,8 +38,9 @@ _.get_run_logs
 # issue_branch_manager.py - Branch operations
 _.delete_linked_branch
 
-# github_utils.py - URL utilities (inverse of parse_github_url)
-_.format_github_https_url
+# github_operations - verification (re-exported via shim)
+_.verify_github
+_.CheckResult
 
 # =============================================================================
 # API COMPLETENESS - IssueEventType Enum Values


### PR DESCRIPTION
## Summary
- Updates shims and usage sites for breaking changes in mcp-workspace 0.1.8
- `get_github_repository_url` → `get_repository_identifier` (returns `RepoIdentifier` instead of URL string)
- Removes deleted `github_utils` imports (`parse_github_url`, `format_github_https_url`, `get_repo_full_name`)
- Adds new `verify_github` and `CheckResult` exports
- Fixes `_repo_full_name` → `_cached_repo_identifier` in `label_transitions.py`
- Updates all test mocks to match new API
- Adds `jenkins_integration` to CLAUDE.md marker exclusion list

## Test plan
- [x] All 3657 unit tests pass
- [x] Pylint clean
- [x] Mypy clean
- [x] CI pipeline passes