### PR TITLE
fix: adapt to mcp-workspace RepoIdentifier cache signature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Python CI
 
 on:
   push:
-    branches: [ "*" ]
+    branches: [ "**" ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:

--- a/src/mcp_coder/cli/commands/coordinator/commands.py
+++ b/src/mcp_coder/cli/commands/coordinator/commands.py
@@ -326,7 +326,7 @@ def execute_coordinator_run(args: argparse.Namespace) -> int:
                     # Update cache with new labels immediately after successful dispatch
                     try:
                         update_issue_labels_in_cache(
-                            repo_full_name=repo_full_name,
+                            RepoIdentifier.from_full_name(repo_full_name),
                             issue_number=issue["number"],
                             old_label=current_label,
                             new_label=workflow_config["next_label"],
@@ -445,7 +445,7 @@ def _build_cached_issues_by_repo(
             # Create issue manager and fetch cached issues
             issue_manager_instance: IssueManager = IssueManager(repo_url=repo_url)
             all_issues = get_all_cached_issues(
-                repo_full_name=repo_full_name,
+                RepoIdentifier.from_full_name(repo_full_name),
                 issue_manager=issue_manager_instance,
                 force_refresh=False,
                 cache_refresh_minutes=get_cache_refresh_minutes(),

--- a/src/mcp_coder/cli/commands/coordinator/core.py
+++ b/src/mcp_coder/cli/commands/coordinator/core.py
@@ -347,7 +347,7 @@ def get_cached_eligible_issues(
     """
     try:
         all_issues = get_all_cached_issues(
-            repo_full_name=repo_full_name,
+            RepoIdentifier.from_full_name(repo_full_name),
             issue_manager=issue_manager,
             force_refresh=force_refresh,
             cache_refresh_minutes=cache_refresh_minutes,

--- a/src/mcp_coder/workflows/vscodeclaude/cleanup.py
+++ b/src/mcp_coder/workflows/vscodeclaude/cleanup.py
@@ -3,7 +3,12 @@
 import logging
 from pathlib import Path
 
-from ...mcp_workspace_github import IssueData, IssueManager, get_all_cached_issues
+from ...mcp_workspace_github import (
+    IssueData,
+    IssueManager,
+    RepoIdentifier,
+    get_all_cached_issues,
+)
 from ...utils.folder_deletion import (
     DeletionFailureReason,
     is_directory_empty,
@@ -110,7 +115,7 @@ def get_stale_sessions(
                     repo_url = f"https://github.com/{repo_full_name}"
                     issue_manager = IssueManager(repo_url=repo_url)
                     fetched = get_all_cached_issues(
-                        repo_full_name=repo_full_name,
+                        RepoIdentifier.from_full_name(repo_full_name),
                         issue_manager=issue_manager,
                         additional_issues=[issue_number],
                     )

--- a/src/mcp_coder/workflows/vscodeclaude/issues.py
+++ b/src/mcp_coder/workflows/vscodeclaude/issues.py
@@ -285,7 +285,7 @@ def get_cached_eligible_vscodeclaude_issues(
     try:
         # Get all issues from cache
         all_issues = get_all_cached_issues(
-            repo_full_name=repo_full_name,
+            RepoIdentifier.from_full_name(repo_full_name),
             issue_manager=issue_manager,
             force_refresh=force_refresh,
             cache_refresh_minutes=cache_refresh_minutes,

--- a/src/mcp_coder/workflows/vscodeclaude/session_launch.py
+++ b/src/mcp_coder/workflows/vscodeclaude/session_launch.py
@@ -9,6 +9,7 @@ from ...mcp_workspace_github import (
     IssueBranchManager,
     IssueData,
     IssueManager,
+    RepoIdentifier,
     get_all_cached_issues,
 )
 from ...utils.subprocess_runner import (
@@ -318,7 +319,7 @@ def process_eligible_issues(
             "process_eligible_issues: no pre-fetched issues provided, fetching from cache"
         )
         all_cached_issues = get_all_cached_issues(
-            repo_full_name=repo_full_name,
+            RepoIdentifier.from_full_name(repo_full_name),
             issue_manager=issue_manager,
             force_refresh=False,
             cache_refresh_minutes=get_cache_refresh_minutes(),

--- a/src/mcp_coder/workflows/vscodeclaude/session_restart.py
+++ b/src/mcp_coder/workflows/vscodeclaude/session_restart.py
@@ -9,6 +9,7 @@ from ...mcp_workspace_github import (
     IssueBranchManager,
     IssueData,
     IssueManager,
+    RepoIdentifier,
     get_all_cached_issues,
 )
 from ...utils.subprocess_runner import (
@@ -172,7 +173,7 @@ def _build_cached_issues_by_repo(
 
             # Fetch with additional_issues to include closed session issues
             all_issues = get_all_cached_issues(
-                repo_full_name=repo_full_name,
+                RepoIdentifier.from_full_name(repo_full_name),
                 issue_manager=issue_manager,
                 force_refresh=False,
                 cache_refresh_minutes=get_cache_refresh_minutes(),
@@ -309,7 +310,7 @@ def restart_closed_sessions(
                 )
                 issue_manager = IssueManager(repo_url=repo_url)
                 fetched = get_all_cached_issues(
-                    repo_full_name=repo_full_name,
+                    RepoIdentifier.from_full_name(repo_full_name),
                     issue_manager=issue_manager,
                     additional_issues=[issue_number],
                 )

--- a/tests/cli/commands/coordinator/test_core.py
+++ b/tests/cli/commands/coordinator/test_core.py
@@ -38,6 +38,7 @@ from mcp_coder.cli.commands.coordinator.command_templates import (
 from mcp_coder.mcp_workspace_github import (
     CacheData,
     IssueData,
+    RepoIdentifier,
     _get_cache_file_path,
     _load_cache_file,
     _log_stale_cache_entries,
@@ -713,7 +714,7 @@ class TestCacheFilePath:
         path = _get_cache_file_path(repo_identifier)
 
         expected_dir = Path.home() / ".mcp_coder" / "coordinator_cache"
-        expected_file = expected_dir / "owner_repo.issues.json"
+        expected_file = expected_dir / "github_com_owner_repo.issues.json"
 
         assert path == expected_file
 
@@ -722,9 +723,18 @@ class TestCacheFilePath:
         from mcp_coder.mcp_workspace_github import RepoIdentifier
 
         test_cases = [
-            ("anthropics/claude-code", "anthropics_claude-code.issues.json"),
-            ("user/repo-with-dashes", "user_repo-with-dashes.issues.json"),
-            ("org/very.long.repo.name", "org_very.long.repo.name.issues.json"),
+            (
+                "anthropics/claude-code",
+                "github_com_anthropics_claude-code.issues.json",
+            ),
+            (
+                "user/repo-with-dashes",
+                "github_com_user_repo-with-dashes.issues.json",
+            ),
+            (
+                "org/very.long.repo.name",
+                "github_com_org_very.long.repo.name.issues.json",
+            ),
         ]
 
         for full_name, expected_filename in test_cases:
@@ -971,7 +981,7 @@ class TestGetCachedEligibleIssues:
 
             assert result == [sample_issue]
             mock_get_all.assert_called_once_with(
-                repo_full_name="owner/repo",
+                RepoIdentifier.from_full_name("owner/repo"),
                 issue_manager=mock_issue_manager,
                 force_refresh=False,
                 cache_refresh_minutes=1440,
@@ -999,7 +1009,7 @@ class TestGetCachedEligibleIssues:
 
             assert result == [sample_issue]
             mock_get_all.assert_called_once_with(
-                repo_full_name="owner/repo",
+                RepoIdentifier.from_full_name("owner/repo"),
                 issue_manager=mock_issue_manager,
                 force_refresh=True,
                 cache_refresh_minutes=1440,
@@ -1026,7 +1036,7 @@ class TestGetCachedEligibleIssues:
 
             assert result == [sample_issue]
             mock_get_all.assert_called_once_with(
-                repo_full_name="owner/repo",
+                RepoIdentifier.from_full_name("owner/repo"),
                 issue_manager=mock_issue_manager,
                 force_refresh=False,
                 cache_refresh_minutes=720,

--- a/tests/cli/commands/coordinator/test_integration.py
+++ b/tests/cli/commands/coordinator/test_integration.py
@@ -13,7 +13,7 @@ import pytest
 from mcp_coder.cli.commands.coordinator import (
     execute_coordinator_run,
 )
-from mcp_coder.mcp_workspace_github import IssueData
+from mcp_coder.mcp_workspace_github import IssueData, RepoIdentifier
 
 
 class TestCoordinatorRunCacheIntegration:
@@ -360,7 +360,7 @@ class TestCacheUpdateIntegration:
 
         # Verify - cache update was called with correct parameters
         mock_update_cache.assert_called_once_with(
-            repo_full_name="user/test_repo",
+            RepoIdentifier.from_full_name("user/test_repo"),
             issue_number=123,
             old_label="status-02:awaiting-planning",
             new_label="status-03:planning",
@@ -451,7 +451,7 @@ class TestCacheUpdateIntegration:
 
         # Verify - cache update was attempted
         mock_update_cache.assert_called_once_with(
-            repo_full_name="user/test_repo",
+            RepoIdentifier.from_full_name("user/test_repo"),
             issue_number=456,
             old_label="status-05:plan-ready",
             new_label="status-06:implementing",
@@ -587,7 +587,7 @@ class TestCacheUpdateIntegration:
         assert mock_update_cache.call_count == 3
         actual_calls = [
             (
-                call[1]["repo_full_name"],
+                call[0][0].full_name,
                 call[1]["issue_number"],
                 call[1]["old_label"],
                 call[1]["new_label"],

--- a/tests/workflows/vscodeclaude/test_issues.py
+++ b/tests/workflows/vscodeclaude/test_issues.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from mcp_coder.mcp_workspace_github import IssueData
+from mcp_coder.mcp_workspace_github import IssueData, RepoIdentifier
 from mcp_coder.workflows.vscodeclaude.issues import (
     _filter_eligible_vscodeclaude_issues,
     build_eligible_issues_with_branch_check,
@@ -439,7 +439,7 @@ class TestGetCachedEligibleVscodeclaudeIssues:
 
         # Verify cache was called
         mock_get_all_cached.assert_called_once_with(
-            repo_full_name="owner/repo",
+            RepoIdentifier.from_full_name("owner/repo"),
             issue_manager=mock_issue_manager,
             force_refresh=False,
             cache_refresh_minutes=1440,

--- a/tests/workflows/vscodeclaude/test_session_restart_branch_integration.py
+++ b/tests/workflows/vscodeclaude/test_session_restart_branch_integration.py
@@ -213,7 +213,7 @@ class TestBranchHandlingIntegration:
 
         monkeypatch.setattr(
             "mcp_coder.workflows.vscodeclaude.session_launch.get_all_cached_issues",
-            lambda **kwargs: mock_issues,
+            lambda *args, **kwargs: mock_issues,
         )
         monkeypatch.setattr(
             "mcp_coder.workflows.vscodeclaude.session_launch._filter_eligible_vscodeclaude_issues",

--- a/tests/workflows/vscodeclaude/test_session_restart_cache.py
+++ b/tests/workflows/vscodeclaude/test_session_restart_cache.py
@@ -5,6 +5,7 @@ restart_closed_sessions() integration with the cache.
 """
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -135,16 +136,16 @@ class TestBuildCachedIssuesByRepo:
 
             # Mock get_all_cached_issues to return different issues for different repos
             def get_cache_side_effect(
-                repo_full_name: str,
+                repo_identifier: Any,
                 issue_manager: Mock,
                 force_refresh: bool,
                 cache_refresh_minutes: int,
                 additional_issues: list[int],
             ) -> list[IssueData]:
-                if repo_full_name == "owner/repo":
+                if repo_identifier.full_name == "owner/repo":
                     # Return both session issues (414, 408) and an open issue (100)
                     return [issue_414, issue_408, issue_100]
-                elif repo_full_name == "other/repo":
+                elif repo_identifier.full_name == "other/repo":
                     # Return session issue (123)
                     return [issue_123]
                 return []
@@ -162,14 +163,14 @@ class TestBuildCachedIssuesByRepo:
 
             # First call should be for "owner/repo" with additional_issues=[414, 408]
             owner_repo_call = next(
-                (c for c in calls if c.kwargs["repo_full_name"] == "owner/repo"), None
+                (c for c in calls if c.args[0].full_name == "owner/repo"), None
             )
             assert owner_repo_call is not None
             assert set(owner_repo_call.kwargs["additional_issues"]) == {414, 408}
 
             # Second call should be for "other/repo" with additional_issues=[123]
             other_repo_call = next(
-                (c for c in calls if c.kwargs["repo_full_name"] == "other/repo"), None
+                (c for c in calls if c.args[0].full_name == "other/repo"), None
             )
             assert other_repo_call is not None
             assert other_repo_call.kwargs["additional_issues"] == [123]


### PR DESCRIPTION
## Summary
- Update all 8 call sites of `get_all_cached_issues` / `update_issue_labels_in_cache` to pass `RepoIdentifier.from_full_name(repo_full_name)` instead of the removed `repo_full_name=` keyword. mcp-workspace's cache helpers now take `RepoIdentifier` as a positional first argument.
- Refresh test mocks/expectations to match the new positional signature, including the new `github_com_` prefix in cache filenames produced by `_get_cache_file_path`.
- Fix `ci.yml` branch trigger: `["*"]` did not match nested names (`fix/...`) because `*` doesn't cross `/` in Actions globs. Switched to `["**"]` so CI fires on slash-named branches.

## Test plan
- [x] `pylint` clean
- [x] `mypy` clean (only pre-existing platform-narrowing warning at `tui_preparation.py:121`, unrelated)
- [x] `pytest` — 3665 passed (full unit suite, integration markers excluded per project convention)
- [x] CI workflow now runs on this branch (verified via `gh run list`)