### PR TITLE
ci: forbid direct URL dependencies in pyproject.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
           - {name: "integration-tests", cmd: "pytest --version && pytest -m 'git_integration or formatter_integration or github_integration' --junitxml=integration-tests.xml"}
           - {name: "mypy", cmd: "mypy --version && mypy --strict src tests"}
           - {name: "file-size", cmd: "mcp-coder check file-size --max-lines 750 --allowlist-file .large-files-allowlist"}
+          - {name: "no-url-deps", cmd: "python tools/check_no_url_deps.py"}
     name: ${{ matrix.check.name }}
     steps:
       - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "isort>=5.12.0",
     "mcp-tools-py",
     "mcp-workspace",
-    "mcp-coder-utils @ git+https://github.com/MarcusJellinghaus/mcp-coder-utils.git",
+    "mcp-coder-utils",
     "PyGithub>=1.59.0",
     "python-jenkins>=1.8.0",
     "requests>=2.28.0",

--- a/tools/check_no_url_deps.py
+++ b/tools/check_no_url_deps.py
@@ -1,0 +1,52 @@
+"""Fail if pyproject.toml [project] dependencies contain direct URL specs.
+
+Direct URL dependencies (e.g. ``pkg @ git+https://...``) are not allowed in
+``[project].dependencies`` or ``[project.optional-dependencies]``. PyPI and
+``twine check`` reject sdists/wheels that include them, and they make the
+project install non-portable.
+
+Use ``[tool.mcp-coder.install-from-github]`` for pre-installing GitHub
+sources via ``tools/reinstall_local.bat`` and the CI install step instead.
+"""
+
+import sys
+import tomllib
+from pathlib import Path
+
+
+def main() -> int:
+    """Return 1 if any direct URL dependency is found, else 0."""
+    project_dir = Path(__file__).resolve().parent.parent
+    path = project_dir / "pyproject.toml"
+
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+
+    project = data.get("project", {})
+    sources: list[tuple[str, str]] = []
+    for dep in project.get("dependencies", []):
+        sources.append(("dependencies", dep))
+    for group, items in project.get("optional-dependencies", {}).items():
+        for dep in items:
+            sources.append((f"optional-dependencies.{group}", dep))
+
+    bad = [
+        (loc, dep)
+        for loc, dep in sources
+        if "git+" in dep or " @ http" in dep or " @ file" in dep
+    ]
+
+    if bad:
+        print("ERROR: direct URL dependencies are not allowed:")
+        for loc, dep in bad:
+            print(f"  [{loc}] {dep}")
+        print()
+        print("Use [tool.mcp-coder.install-from-github] for git installs.")
+        return 1
+
+    print("OK: no direct URL dependencies in [project]")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add `tools/check_no_url_deps.py` to fail if `[project].dependencies` or `[project.optional-dependencies]` contain direct URL specs (`git+`, `@ http`, `@ file`).
- Wire the check into the CI matrix as `no-url-deps`.
- Drop the `git+https://...` URL from `mcp-coder-utils` in `pyproject.toml` so the project itself passes — git installs continue to flow through `[tool.mcp-coder.install-from-github]`.

## Test plan
- [ ] `python tools/check_no_url_deps.py` exits 0 on this branch
- [ ] CI `no-url-deps` job passes
- [ ] Reintroducing a `git+` dep locally causes the script to exit 1