### PR TITLE
fix(verify): pass MCP_CODER_* env vars to smoke test and test prompt

### DIFF
--- a/src/mcp_coder/cli/commands/verify.py
+++ b/src/mcp_coder/cli/commands/verify.py
@@ -438,6 +438,7 @@ def _run_mcp_edit_smoke_test(
     mcp_config: str,
     execution_dir: str,
     symbols: dict[str, str],
+    env_vars: dict[str, str] | None = None,
 ) -> str:
     """Run MCP edit smoke test.
 
@@ -447,6 +448,8 @@ def _run_mcp_edit_smoke_test(
         mcp_config: Path to the MCP config file.
         execution_dir: Execution directory path.
         symbols: Dict with 'success', 'failure', 'warning' keys.
+        env_vars: Environment variables passed to the LLM subprocess so
+            ``${MCP_CODER_*}`` placeholders in ``.mcp.json`` resolve.
 
     Returns:
         Formatted output line for the smoke test result.
@@ -461,6 +464,7 @@ def _run_mcp_edit_smoke_test(
             timeout=60,
             mcp_config=mcp_config,
             execution_dir=execution_dir,
+            env_vars=env_vars,
         )
         content = test_file.read_text(encoding="utf-8")
         pos_a, pos_b, pos_c = content.find("A"), content.find("B"), content.find("C")
@@ -723,10 +727,13 @@ def execute_verify(args: argparse.Namespace) -> int:
     # 3a. MCP server health checks (provider-aware ordering)
     mcp_result: dict[str, Any] | None = None
     claude_mcp: list[ClaudeMCPStatus] | None = None
+    # Compute MCP_CODER_* env vars once: needed by the Claude/LangChain MCP
+    # health checks AND by the smoke test / test prompt below so .mcp.json
+    # placeholders like ${MCP_CODER_VENV_PATH} resolve in the subprocess.
+    env_vars = prepare_llm_environment(project_dir)
 
     if mcp_config_resolved:
         # Run Claude MCP list
-        env_vars = prepare_llm_environment(project_dir)
         claude_exe = find_claude_executable(return_none_if_not_found=True)
         claude_mcp = parse_claude_mcp_list(env_vars, claude_executable=claude_exe)
 
@@ -844,6 +851,7 @@ def execute_verify(args: argparse.Namespace) -> int:
             mcp_config_resolved,
             str(project_dir),
             symbols,
+            env_vars=env_vars,
         )
         print(smoke_line)
 
@@ -857,6 +865,7 @@ def execute_verify(args: argparse.Namespace) -> int:
             timeout=30,
             mcp_config=mcp_config_resolved,
             execution_dir=str(project_dir),
+            env_vars=env_vars,
         )
         print(_format_row("Test prompt", symbols["success"], "responded OK", indent=2))
     except Exception as exc:  # pylint: disable=broad-except

--- a/tests/cli/commands/test_verify_orchestration.py
+++ b/tests/cli/commands/test_verify_orchestration.py
@@ -1054,6 +1054,64 @@ class TestVerifyMcpAllProviders:
         call_kwargs = mock_smoke_test.call_args
         assert call_kwargs[0][2] == "/fake/.mcp.json"  # mcp_config arg
 
+    @patch(
+        f"{_VERIFY}._run_mcp_edit_smoke_test",
+        return_value="  MCP edit smoke test  [OK] edit verified",
+    )
+    @patch(f"{_VERIFY}.parse_claude_mcp_list", return_value=[])
+    @patch(
+        f"{_VERIFY}.prepare_llm_environment",
+        return_value={
+            "MCP_CODER_PROJECT_DIR": "/proj",
+            "MCP_CODER_VENV_DIR": "/venv",
+            "MCP_CODER_VENV_PATH": "/venv/Scripts",
+        },
+    )
+    @patch(f"{_VERIFY}.log_to_mlflow", create=True)
+    @patch(f"{_VERIFY}.prompt_llm")
+    @patch(f"{_VERIFY}.resolve_mcp_config_path", return_value="/fake/.mcp.json")
+    @patch(f"{_LC_VERIFY}.verify_mcp_servers")
+    @patch(f"{_VERIFY}.verify_mlflow")
+    @patch(f"{_VERIFY}.verify_claude")
+    @patch(f"{_VERIFY}.resolve_llm_method")
+    def test_env_vars_passed_to_smoke_test_and_test_prompt(
+        self,
+        mock_provider: MagicMock,
+        mock_claude: MagicMock,
+        mock_mlflow: MagicMock,
+        mock_mcp_servers: MagicMock,
+        mock_resolve_mcp: MagicMock,
+        mock_prompt_llm: MagicMock,
+        _mock_log_mlflow: MagicMock,
+        _mock_prepare_env: MagicMock,
+        _mock_claude_mcp: MagicMock,
+        mock_smoke_test: MagicMock,
+    ) -> None:
+        """env_vars from prepare_llm_environment flow to smoke test + test prompt.
+
+        Without these, MCP servers can't expand ${MCP_CODER_VENV_PATH} etc. in
+        .mcp.json, mirroring the env that icoder threads through RuntimeInfo.
+        """
+        mock_provider.return_value = ("claude", "default")
+        mock_claude.return_value = _claude_ok()
+        mock_mlflow.return_value = _mlflow_not_installed()
+        mock_prompt_llm.return_value = _minimal_llm_response()
+        mock_mcp_servers.return_value = _mcp_servers_ok()
+
+        execute_verify(_make_args(mcp_config=".mcp.json"))
+
+        expected_env = {
+            "MCP_CODER_PROJECT_DIR": "/proj",
+            "MCP_CODER_VENV_DIR": "/venv",
+            "MCP_CODER_VENV_PATH": "/venv/Scripts",
+        }
+        # Smoke test received env_vars (kwarg)
+        smoke_kwargs = mock_smoke_test.call_args.kwargs
+        assert smoke_kwargs.get("env_vars") == expected_env
+        # Unified test prompt received env_vars (kwarg)
+        prompt_kwargs = mock_prompt_llm.call_args.kwargs
+        assert prompt_kwargs.get("env_vars") == expected_env
+
 
 class TestMcpConfigWarnings:
     """Tests for ``_collect_mcp_warnings`` parser and rendered section."""


### PR DESCRIPTION
## Summary
- `mcp-coder verify` was launching the MCP edit smoke test and the unified test prompt without the `MCP_CODER_*` env vars that `prepare_llm_environment()` builds. As a result, `.mcp.json` placeholders like `${MCP_CODER_VENV_PATH}` stayed unresolved at subprocess start and `tools-py` failed to launch (`FileNotFoundError`).
- Hoist the env-var computation out of the MCP-only block so it's also visible to the smoke test and test prompt, thread `env_vars` through `_run_mcp_edit_smoke_test`, and pass it to both `prompt_llm` calls — matching how `icoder` already supplies these via `RuntimeInfo.env_vars`.
- Adds a focused orchestration test asserting `env_vars` flows to both call sites.

## Repro (before)
```
=== MCP CONFIG WARNINGS ===================================================
  tools-py / PYTHONPATH  [WARN] ${MCP_CODER_PROJECT_DIR}/src
  workspace / PYTHONPATH [WARN] ${MCP_CODER_VENV_DIR}\Lib\
  MCP edit smoke test    [WARN] edit not verified (MCP server 'tools-py' failed to launch: ${MCP_CODER_VENV_PATH}\mcp-tools-py.exe (FileNotFoundError))
  Test prompt            [ERR]  FAILED (LLMMCPLaunchError: MCP server 'tools-py' failed to launch: ${MCP_CODER_VENV_PATH}\mcp-tools-py.exe (FileNotFoundError))
```

The `MCP CONFIG WARNINGS` section is unchanged — it's a static lint of `.mcp.json` and intentionally doesn't try to resolve placeholders. The actionable fix was the runtime path used by the smoke test and test prompt.

## Test plan
- [x] `pylint` clean
- [x] `mypy` clean
- [x] Full unit-test suite: 3703 passed (excluding integration markers)
- [x] New `test_env_vars_passed_to_smoke_test_and_test_prompt` asserts both call sites receive the dict from `prepare_llm_environment`
- [ ] Re-run `mcp-coder verify` locally on a project with `${MCP_CODER_*}` placeholders in `.mcp.json` and confirm the smoke test + test prompt now succeed