### PR TITLE
fix(tests): add missing error_category key to CommitResult literal

### DIFF
--- a/tests/test_module_integration.py
+++ b/tests/test_module_integration.py
@@ -91,6 +91,7 @@ class TestModuleIntegration:
             "success": True,
             "commit_hash": "abc1234",
             "error": None,
+            "error_category": None,
         }
 
         assert sample_result["success"] is True


### PR DESCRIPTION
## Summary
- Adds the missing `error_category` key to the `CommitResult` TypedDict literal in `tests/test_module_integration.py::test_commit_result_type_import`
- `CommitResult` (from `mcp_workspace.git_operations.core`) is a total TypedDict requiring all four keys: `success`, `commit_hash`, `error`, `error_category`
- Fixes mypy strict failure on CI

## Test plan
- [x] `mypy --strict src tests` — 0 errors (435 files)
- [x] `pytest tests/test_module_integration.py` — 7/7 passed
- [x] `pylint tests/test_module_integration.py` — 10.00/10
- [x] `black` / `isort` — clean