### PR TITLE
fix(create-pr): handle empty dict from failed PR creation

### DIFF
--- a/src/mcp_coder/workflows/create_pr/core.py
+++ b/src/mcp_coder/workflows/create_pr/core.py
@@ -600,7 +600,7 @@ def run_create_pr_workflow(
         # Step 5: Create pull request
         logger.log(OUTPUT, "Step 5/5: Creating pull request...")
         pr_result, pr_error = create_pull_request(project_dir, title, body)
-        if pr_result is None:
+        if not pr_result:
             error_msg = pr_error or "Failed to create pull request"
             logger.error(error_msg)
             elapsed = time.time() - start_time


### PR DESCRIPTION
## Summary

- Fix `KeyError: 'number'` crash when `create_pull_request` returns an empty dict on API failure (e.g. PR already exists, 422 response)
- The upstream `PullRequestManager.create_pull_request()` returns `{}` (not `None`) on error via the `_handle_github_errors` decorator
- Change check from `if pr_result is None` to `if not pr_result` to catch both `None` and empty dict

## Test plan

- [ ] Verify `create-pr` workflow handles "PR already exists" (422) gracefully instead of crashing
- [ ] Verify normal PR creation still works end-to-end