### PR TITLE
fix(mypy): remove stale overrides for mcp_workspace modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,13 +217,6 @@ python_version = "3.11"
 disable_error_code = ["import-untyped"]
 
 [[tool.mypy.overrides]]
-module = ["mcp_coder.mcp_workspace_github"]
-# Sentinel fallback assignments intentionally conflict with the try-branch types;
-# which error code fires (assignment vs misc) depends on whether the name is a
-# class or callable, so we suppress unused-ignore for this module.
-disable_error_code = ["assignment", "misc", "unused-ignore"]
-
-[[tool.mypy.overrides]]
 module = ["pytest.*"]
 ignore_missing_imports = true
 
@@ -232,10 +225,6 @@ module = ["tests.*"]
 # Disable unreachable warnings for test files due to mypy false positives with assertions
 # Disable union-attr for test files where mocked attributes are intentionally set
 disable_error_code = ["unreachable", "union-attr"]
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = ["mcp_workspace.github_operations", "mcp_workspace.github_operations.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
## Summary

- Remove `ignore_missing_imports` override for `mcp_workspace.github_operations` — with `mcp_workspace` properly installed (ships `py.typed`), mypy resolves types directly
- Remove dead `disable_error_code` override for `mcp_coder.mcp_workspace_github` — was for sentinel fallback assignments that no longer exist in the file
- Enables real cross-repo interface type checking between `mcp_coder` and `mcp_workspace`

## Test plan

- [x] `mypy --strict` passes with both overrides removed
- [ ] CI passes