### PR TITLE
fix(install): retry venv wipe and handle read-only files

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -60,8 +60,10 @@ from __future__ import annotations
 import argparse
 import os
 import shutil
+import stat
 import subprocess
 import sys
+import time
 import tomllib
 from pathlib import Path
 
@@ -241,6 +243,46 @@ def _source_dir_for_overrides(args: argparse.Namespace) -> Path | None:
     return REPO_ROOT
 
 
+def _rmtree_onexc(func, path, _exc):  # type: ignore[no-untyped-def]
+    """rmtree error handler: clear the read-only bit and retry."""
+    try:
+        os.chmod(path, stat.S_IWRITE)
+    except OSError:
+        pass
+    func(path)
+
+
+def _rmtree_with_retry(path: Path, attempts: int = 3, delay: float = 1.0) -> None:
+    """Robust ``shutil.rmtree`` for Windows: handles read-only files and a
+    transient lock (e.g. an antivirus or just-exited process still holding
+    a handle) via a small retry. On final failure, exits with a clear
+    message naming the locked file.
+    """
+    kwargs = (
+        {"onexc": _rmtree_onexc}
+        if sys.version_info >= (3, 12)
+        else {"onerror": _rmtree_onexc}
+    )
+    last_err: PermissionError | None = None
+    for i in range(attempts):
+        try:
+            shutil.rmtree(path, **kwargs)  # type: ignore[arg-type]
+            return
+        except PermissionError as e:
+            last_err = e
+            if i < attempts - 1:
+                time.sleep(delay)
+    assert last_err is not None
+    locked = last_err.filename or "<unknown>"
+    sys.exit(
+        f"ERROR: could not delete {path}\n"
+        f"  locked file: {locked}\n"
+        f"  Another process is holding a file in this directory open.\n"
+        f"  Close any python.exe, mcp-* servers, IDEs, or shells using\n"
+        f"  this venv, then re-run."
+    )
+
+
 def _phase_venv(target: Path, venv: Path, args: argparse.Namespace) -> None:
     """Phase 1+2: prepare the target dir and (re)create the venv.
 
@@ -252,7 +294,7 @@ def _phase_venv(target: Path, venv: Path, args: argparse.Namespace) -> None:
     if args.clean and venv.exists():
         print(f"--- wiping {venv}")
         if not args.check:
-            shutil.rmtree(venv)
+            _rmtree_with_retry(venv)
     if venv.exists():
         return
     uv_bootstrap = shutil.which("uv")


### PR DESCRIPTION
## Summary

`tools/install.py` (the standalone bootstrap installer) was calling plain `shutil.rmtree(venv)` in `_phase_venv` with no error handler. Any read-only `.pyd`/`.dll` left over from a prior install, or any transient file lock (antivirus, a just-exited `python.exe` still holding a handle), aborted `install.py --clean` with a raw `PermissionError` traceback.

This came up running `jenkins-windows/setup/create-environment.bat` (in `AutoRunner`), which curls and runs this script:

```
PermissionError: [WinError 5] Access is denied:
'C:\Jenkins\environments\mcp-coder-dev\.venv\Lib\site-packages\charset_normalizer\cd.cp313-win_amd64.pyd'
```

## Changes

Wraps the wipe in a small helper that:

- clears the read-only bit via an `onexc`/`onerror` callback (mirrors `_rmtree_remove_readonly` in `src/mcp_coder/utils/folder_deletion.py`)
- retries up to **3 times with a 1s gap** to ride out transient locks
- on final failure, prints a **clear actionable message** naming the locked file ("close python.exe / MCP servers / IDEs / shells using the venv, then re-run") instead of dumping a traceback

Deliberately kept simple — **no process killing**, no `handle64.exe`, no staging-directory move. `install.py` is `stdlib-only` (must run before mcp-coder is installed), so it can't import `mcp_coder.utils.folder_deletion`; the inline copy is minimal by design.

Net diff: `+43 / -1`, adds `import stat` and `import time`.

## Test plan

- [x] `python -c "import ast; ast.parse(open('tools/install.py').read())"` — parses
- [x] `python tools/install.py --help` — CLI still works
- [x] Smoke test: create a tempdir containing a read-only file, call `_rmtree_with_retry` — directory is deleted (without the fix, plain `rmtree` raises)
- [x] `mypy tools/install.py` — clean
- [x] `pylint tools/install.py` — only the pre-existing `W1510` (unrelated, line 207)
- [ ] End-to-end: re-run `create-environment.bat` against the venv that originally triggered the bug