### PR TITLE
docs(skills): read linked issues in issue-consuming skills

### DIFF
--- a/.claude/skills/implement_direct/SKILL.md
+++ b/.claude/skills/implement_direct/SKILL.md
@@ -25,6 +25,7 @@ If no issue number is provided:
 1. **Fetch issue details**
    Call `mcp__mcp-workspace__github_issue_view` with the issue number.
    Read the issue title, description, and acceptance criteria carefully.
+   **Read linked issues first.** If the issue points to an epic, design doc, dependencies, or sibling issues, read those before implementing — it may not be self-contained, and any "read first" note is mandatory.
 
 2. **Checkout/create issue branch**
    ```bash

--- a/.claude/skills/implementation_review_supervisor/SKILL.md
+++ b/.claude/skills/implementation_review_supervisor/SKILL.md
@@ -22,7 +22,7 @@ You are a technical lead supervising a software engineer (subagent). You do not 
 
 **Setup:**
 
-1. Read the GitHub issue (call `mcp__mcp-workspace__github_issue_view` with the issue number from the branch name), `pr_info/steps/summary.md`, and `pr_info/steps/Decisions.md` (if it exists) to understand requirements and design decisions.
+1. Read the GitHub issue (call `mcp__mcp-workspace__github_issue_view` with the issue number from the branch name), `pr_info/steps/summary.md`, and `pr_info/steps/Decisions.md` (if it exists) to understand requirements and design decisions. **Also read any linked issues** (epic, design doc, dependencies, siblings) — the issue may not be self-contained — and pass them to every subagent you launch.
 2. Read the knowledge base files:
    - `.claude/knowledge_base/software_engineering_principles.md`
    - `.claude/knowledge_base/python.md`

--- a/.claude/skills/issue_analyse/SKILL.md
+++ b/.claude/skills/issue_analyse/SKILL.md
@@ -25,6 +25,8 @@ Wait one second using `mcp__mcp-tools-py__sleep` with `seconds: 1`
 
 Fetch the issue using `mcp__mcp-workspace__github_issue_view`.
 
+**Read linked issues first.** If the issue points to an epic, design doc, dependencies, or sibling issues, read those before analysing — it may not be self-contained, and any "read first" note is mandatory.
+
 ## Instructions
 
 Analyze the issue:

--- a/.claude/skills/issue_analyse_supervisor/SKILL.md
+++ b/.claude/skills/issue_analyse_supervisor/SKILL.md
@@ -15,7 +15,7 @@ You are a technical lead supervising a software engineer (subagent). You do not 
 **Setup:**
 
 1. Resolve the issue number from `$ARGUMENTS`, the branch name, or `.vscodeclaude_status.txt`. If none found, ask the user.
-2. Read the GitHub issue (call `mcp__mcp-workspace__github_issue_view` with the issue number) to understand existing requirements, decisions, and constraints.
+2. Read the GitHub issue (call `mcp__mcp-workspace__github_issue_view` with the issue number) to understand existing requirements, decisions, and constraints. **Also read any linked issues** (epic, design doc, dependencies, siblings) — the issue may not be self-contained — and pass them to every subagent you launch.
 3. Read the knowledge base files:
    - `.claude/knowledge_base/software_engineering_principles.md`
    - `.claude/knowledge_base/planning_principles.md`

--- a/.claude/skills/issue_create/SKILL.md
+++ b/.claude/skills/issue_create/SKILL.md
@@ -17,6 +17,8 @@ Based on our prior discussion, create a GitHub issue.
 3. Include relevant details from our discussion in the body
 4. Use markdown formatting for better readability
 
+**Link related issues.** If the issue belongs to an epic or design doc, or has dependencies, list them near the top and in a `## Dependencies / references` section — the epic, design doc, dependencies, and any curated sibling issues worth reading. Add a short "read these first" note when they're essential. Omit for standalone issues.
+
 **Optional: Base Branch**
 If the feature should be based on a branch other than the default (main/master), include:
 

--- a/.claude/skills/issue_update/SKILL.md
+++ b/.claude/skills/issue_update/SKILL.md
@@ -53,4 +53,4 @@ The base branch must be a single line. Multiple lines will cause an error during
 - Discussed implementation approach (concise)
 - `## Constraints & Rationale` — non-obvious gotchas and the "why" behind decisions. Skip if none identified.
 - `## Decisions` table — decided topics so `/issue_analyse` won't re-ask. Skip if none yet.
-- **Links to related issues** — preserve the epic, design doc, dependencies, and curated siblings when rewriting; add them if missing and the issue isn't standalone.
+- **`## Dependencies / references`** — preserve the links to the epic, design doc, dependencies, and curated siblings when rewriting; add the section if missing and the issue isn't standalone.

--- a/.claude/skills/issue_update/SKILL.md
+++ b/.claude/skills/issue_update/SKILL.md
@@ -53,3 +53,4 @@ The base branch must be a single line. Multiple lines will cause an error during
 - Discussed implementation approach (concise)
 - `## Constraints & Rationale` — non-obvious gotchas and the "why" behind decisions. Skip if none identified.
 - `## Decisions` table — decided topics so `/issue_analyse` won't re-ask. Skip if none yet.
+- **Links to related issues** — preserve the epic, design doc, dependencies, and curated siblings when rewriting; add them if missing and the issue isn't standalone.

--- a/.claude/skills/plan_review_supervisor/SKILL.md
+++ b/.claude/skills/plan_review_supervisor/SKILL.md
@@ -18,7 +18,7 @@ You are a technical lead supervising a software engineer (subagent). You do not 
 
 **Setup:**
 
-1. Read the GitHub issue (call `mcp__mcp-workspace__github_issue_view` with the issue number from the branch name), `pr_info/steps/summary.md`, and `pr_info/steps/Decisions.md` (if it exists) to understand requirements and design decisions.
+1. Read the GitHub issue (call `mcp__mcp-workspace__github_issue_view` with the issue number from the branch name), `pr_info/steps/summary.md`, and `pr_info/steps/Decisions.md` (if it exists) to understand requirements and design decisions. **Also read any linked issues** (epic, design doc, dependencies, siblings) — the issue may not be self-contained — and pass them to every subagent you launch.
 2. Read the knowledge base files:
    - `.claude/knowledge_base/software_engineering_principles.md`
    - `.claude/knowledge_base/planning_principles.md`

--- a/src/mcp_coder/prompts/prompts.md
+++ b/src/mcp_coder/prompts/prompts.md
@@ -205,6 +205,7 @@ Three-prompt sequence for generating implementation plans from GitHub issues.
 ```
 ## Discuss implementation steps
 Please take a look at the existing solution, its files and its architecture documentation.
+If the task links an epic, design doc, dependencies, or sibling issues, read those first — it may not be self-contained.
 Do you understand the task below?
 What are the implementation steps?
 Do not yet modify any code!


### PR DESCRIPTION
## Why

Issue-consuming skills fetched only the named issue and stopped. When an issue is part of an epic/design and says so (e.g. #1039's *"don't implement from this issue alone"*), that context was silently missed — as happened during a real `/issue_analyse` session.

## What

Added a concise, tool-agnostic instruction so the workflow reliably follows an issue's links, end to end:

**Read side** — read the linked epic / design doc / dependencies / siblings before acting:
- `issue_analyse`, `implement_direct`
- `issue_analyse_supervisor`, `implementation_review_supervisor`, `plan_review_supervisor` (also pass the linked context to their subagents, which start fresh)
- autonomous plan-gen prompt in `src/mcp_coder/prompts/prompts.md`

**Write side** — keep the links present so the read side can follow them:
- `issue_create` / `issue_update` — maintain a `## Dependencies / references` section (curated siblings, not the epic's whole list); omit for standalone issues

## Notes

- Guidance is deliberately short and free of tool names; the model reads links semantically (no rigid section-name parsing required).
- Docs/prompts only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)