### PR TITLE
Add branch-cleanup tool to prune merged local branches

### DIFF
--- a/tools/branch-cleanup/README.md
+++ b/tools/branch-cleanup/README.md
@@ -13,6 +13,14 @@ Run from the root of any clone of the repo:
 ./tools/branch-cleanup/prune-branches.ps1 -Main master   # different base branch
 ```
 
+Or double-click / call the `.bat` launcher, which forwards the same flags
+and picks whichever PowerShell is installed:
+
+```bat
+tools\branch-cleanup\prune-branches.bat
+tools\branch-cleanup\prune-branches.bat -Delete
+```
+
 ## How it classifies
 
 - **Protected:** the current branch and `main` are never touched.

--- a/tools/branch-cleanup/README.md
+++ b/tools/branch-cleanup/README.md
@@ -1,0 +1,32 @@
+# branch-cleanup
+
+Find and delete local git branches that are already merged (including
+GitHub squash-merges, which `git branch --merged` cannot detect on its own).
+
+## Usage
+
+Run from the root of any clone of the repo:
+
+```powershell
+./tools/branch-cleanup/prune-branches.ps1          # dry run: classify only
+./tools/branch-cleanup/prune-branches.ps1 -Delete  # delete the merged branches
+./tools/branch-cleanup/prune-branches.ps1 -Main master   # different base branch
+```
+
+## How it classifies
+
+- **Protected:** the current branch and `main` are never touched.
+- **Merged / obsolete:** the branch tip is reachable from `main`
+  (`git branch --merged`) **or** GitHub reports a merged PR for it.
+  The PR check is what catches squash-merges.
+- **Active:** everything else — kept.
+
+Deletion uses `git branch -D` because squash-merged branches are not
+"merged" from git's point of view (their commits never land in `main`).
+
+## Requirements
+
+- PowerShell (`pwsh` or Windows PowerShell 5.1).
+- [`gh`](https://cli.github.com/) installed and authenticated (`gh auth status`).
+  Without it the script still runs but warns and can only detect true
+  fast-forward / merge-commit branches, missing squash-merges.

--- a/tools/branch-cleanup/README.md
+++ b/tools/branch-cleanup/README.md
@@ -5,12 +5,19 @@ GitHub squash-merges, which `git branch --merged` cannot detect on its own).
 
 ## Usage
 
-Run from the root of any clone of the repo:
+Run from the root of a clone (operates on the current directory)...
 
 ```powershell
 ./tools/branch-cleanup/prune-branches.ps1          # dry run: classify only
 ./tools/branch-cleanup/prune-branches.ps1 -Delete  # delete the merged branches
 ./tools/branch-cleanup/prune-branches.ps1 -Main master   # different base branch
+```
+
+...or run it from anywhere and point it at a clone with `-Path`:
+
+```powershell
+./tools/branch-cleanup/prune-branches.ps1 -Path C:\code\other-clone
+./tools/branch-cleanup/prune-branches.ps1 -Path C:\code\other-clone -Delete
 ```
 
 Or double-click / call the `.bat` launcher, which forwards the same flags

--- a/tools/branch-cleanup/README.md
+++ b/tools/branch-cleanup/README.md
@@ -41,7 +41,14 @@ Deletion uses `git branch -D` because squash-merged branches are not
 
 ## Requirements
 
-- PowerShell (`pwsh` or Windows PowerShell 5.1).
-- [`gh`](https://cli.github.com/) installed and authenticated (`gh auth status`).
-  Without it the script still runs but warns and can only detect true
-  fast-forward / merge-commit branches, missing squash-merges.
+- **git** and **PowerShell** (`pwsh` or Windows PowerShell 5.1).
+- **[`gh`](https://cli.github.com/) installed and authenticated** (`gh auth status`).
+  Effectively **required** if you squash-merge: a squash collapses the branch
+  into one new commit on `main`, so the branch's own commits never land there
+  and `git branch --merged` cannot see it. The `gh` merged-PR lookup is the
+  only path that detects squash-merged branches — without it the tool warns
+  and detects almost nothing on a squash workflow.
+
+The `gh` lookup covers the 1000 most recently merged PRs. If a merged branch
+is older than that, it is classified **active** and kept (never wrongly
+deleted) — clean those few up by hand.

--- a/tools/branch-cleanup/prune-branches.bat
+++ b/tools/branch-cleanup/prune-branches.bat
@@ -1,0 +1,8 @@
+@echo off
+rem Launcher for prune-branches.ps1 - forwards all args (e.g. -Delete, -Main master).
+rem Prefers PowerShell 7 (pwsh); falls back to built-in Windows PowerShell 5.1.
+where pwsh >nul 2>nul && (
+  pwsh -NoProfile -ExecutionPolicy Bypass -File "%~dp0prune-branches.ps1" %*
+) || (
+  powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0prune-branches.ps1" %*
+)

--- a/tools/branch-cleanup/prune-branches.ps1
+++ b/tools/branch-cleanup/prune-branches.ps1
@@ -1,0 +1,86 @@
+<#
+.SYNOPSIS
+  Classify local git branches as merged (obsolete) or active, and optionally delete the merged ones.
+
+.DESCRIPTION
+  A branch is considered MERGED if either:
+    - its tip is reachable from the main branch (git branch --merged), OR
+    - GitHub reports a merged PR for it (catches squash-merges, which --merged misses).
+
+  The current branch and the main branch are always protected.
+
+.PARAMETER Delete
+  Actually delete the merged branches (git branch -D). Without this flag, the script only reports.
+
+.PARAMETER Main
+  Name of the main/base branch. Defaults to 'main'.
+
+.EXAMPLE
+  ./scripts/prune-branches.ps1            # dry run: just show the classification
+  ./scripts/prune-branches.ps1 -Delete    # delete the merged branches
+#>
+[CmdletBinding()]
+param(
+    [switch]$Delete,
+    [string]$Main = 'main'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Refresh remote state and prune stale remote-tracking refs.
+Write-Host "Fetching + pruning remotes..." -ForegroundColor Cyan
+git fetch --all --prune | Out-Null
+
+$current = (git rev-parse --abbrev-ref HEAD).Trim()
+$hasGh   = [bool](Get-Command gh -ErrorAction SilentlyContinue)
+if (-not $hasGh) {
+    Write-Warning "gh CLI not found - squash-merged branches will NOT be detected."
+}
+
+# Branches whose tip is an ancestor of main (classic merge detection).
+$mergedByGit = @(git branch --merged $Main --format '%(refname:short)') |
+    Where-Object { $_ -and $_ -ne $Main }
+
+$branches = @(git branch --format '%(refname:short)') |
+    Where-Object { $_ -and $_ -ne $Main -and $_ -ne $current }
+
+$merged = [System.Collections.Generic.List[object]]::new()
+$active = [System.Collections.Generic.List[string]]::new()
+
+foreach ($b in $branches) {
+    $reason = $null
+    if ($mergedByGit -contains $b) {
+        $reason = 'merged into main'
+    }
+    elseif ($hasGh) {
+        # Ask GitHub whether a merged PR exists for this branch (squash-merge case).
+        $pr = gh pr list --head $b --state merged --json number,title --limit 1 2>$null | ConvertFrom-Json
+        if ($pr) { $reason = "PR #$($pr[0].number) merged" }
+    }
+
+    if ($reason) { $merged.Add([pscustomobject]@{ Branch = $b; Reason = $reason }) }
+    else         { $active.Add($b) }
+}
+
+Write-Host ""
+Write-Host "ACTIVE (keep): $($active.Count)" -ForegroundColor Green
+$active | ForEach-Object { Write-Host "  $_" }
+Write-Host "  * $current  (current, protected)" -ForegroundColor DarkGray
+
+Write-Host ""
+Write-Host "MERGED / obsolete: $($merged.Count)" -ForegroundColor Yellow
+$merged | ForEach-Object { Write-Host ("  {0,-55} {1}" -f $_.Branch, $_.Reason) }
+
+if (-not $Delete) {
+    Write-Host ""
+    Write-Host "Dry run. Re-run with -Delete to remove the $($merged.Count) merged branch(es)." -ForegroundColor Cyan
+    return
+}
+
+if ($merged.Count -eq 0) { Write-Host "`nNothing to delete." -ForegroundColor Green; return }
+
+Write-Host ""
+foreach ($m in $merged) {
+    git branch -D $m.Branch
+}
+Write-Host "Deleted $($merged.Count) branch(es)." -ForegroundColor Green

--- a/tools/branch-cleanup/prune-branches.ps1
+++ b/tools/branch-cleanup/prune-branches.ps1
@@ -15,17 +15,28 @@
 .PARAMETER Main
   Name of the main/base branch. Defaults to 'main'.
 
+.PARAMETER Path
+  Path to the repo to operate on. Defaults to the current directory.
+
 .EXAMPLE
-  ./tools/branch-cleanup/prune-branches.ps1            # dry run: just show the classification
+  ./tools/branch-cleanup/prune-branches.ps1            # dry run in the current repo
   ./tools/branch-cleanup/prune-branches.ps1 -Delete    # delete the merged branches
+  ./tools/branch-cleanup/prune-branches.ps1 -Path C:\code\other-clone   # target another clone
 #>
 [CmdletBinding()]
 param(
     [switch]$Delete,
-    [string]$Main = 'main'
+    [string]$Main = 'main',
+    [string]$Path = '.'
 )
 
 $ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path (Join-Path $Path '.git'))) {
+    throw "Not a git repository: $Path"
+}
+Push-Location $Path
+try {
 
 # Refresh remote state and prune stale remote-tracking refs.
 Write-Host "Fetching + pruning remotes..." -ForegroundColor Cyan
@@ -88,3 +99,8 @@ foreach ($m in $merged) {
     git branch -D $m.Branch
 }
 Write-Host "Deleted $($merged.Count) branch(es)." -ForegroundColor Green
+
+}
+finally {
+    Pop-Location
+}

--- a/tools/branch-cleanup/prune-branches.ps1
+++ b/tools/branch-cleanup/prune-branches.ps1
@@ -55,7 +55,7 @@ $mergedByGit = @(git branch --merged $Main --format '%(refname:short)') |
 # Head-branch names of merged PRs, fetched in one call (catches squash-merges).
 $mergedPrHeads = @()
 if ($hasGh) {
-    $mergedPrHeads = @(gh pr list --state merged --limit 500 --json headRefName --jq '.[].headRefName')
+    $mergedPrHeads = @(gh pr list --state merged --limit 1000 --json headRefName --jq '.[].headRefName')
 }
 
 $branches = @(git branch --format '%(refname:short)') |

--- a/tools/branch-cleanup/prune-branches.ps1
+++ b/tools/branch-cleanup/prune-branches.ps1
@@ -16,8 +16,8 @@
   Name of the main/base branch. Defaults to 'main'.
 
 .EXAMPLE
-  ./scripts/prune-branches.ps1            # dry run: just show the classification
-  ./scripts/prune-branches.ps1 -Delete    # delete the merged branches
+  ./tools/branch-cleanup/prune-branches.ps1            # dry run: just show the classification
+  ./tools/branch-cleanup/prune-branches.ps1 -Delete    # delete the merged branches
 #>
 [CmdletBinding()]
 param(
@@ -41,6 +41,12 @@ if (-not $hasGh) {
 $mergedByGit = @(git branch --merged $Main --format '%(refname:short)') |
     Where-Object { $_ -and $_ -ne $Main }
 
+# Head-branch names of merged PRs, fetched in one call (catches squash-merges).
+$mergedPrHeads = @()
+if ($hasGh) {
+    $mergedPrHeads = @(gh pr list --state merged --limit 500 --json headRefName --jq '.[].headRefName')
+}
+
 $branches = @(git branch --format '%(refname:short)') |
     Where-Object { $_ -and $_ -ne $Main -and $_ -ne $current }
 
@@ -52,10 +58,8 @@ foreach ($b in $branches) {
     if ($mergedByGit -contains $b) {
         $reason = 'merged into main'
     }
-    elseif ($hasGh) {
-        # Ask GitHub whether a merged PR exists for this branch (squash-merge case).
-        $pr = gh pr list --head $b --state merged --json number,title --limit 1 2>$null | ConvertFrom-Json
-        if ($pr) { $reason = "PR #$($pr[0].number) merged" }
+    elseif ($mergedPrHeads -contains $b) {
+        $reason = 'merged via PR (squash)'
     }
 
     if ($reason) { $merged.Add([pscustomobject]@{ Branch = $b; Reason = $reason }) }


### PR DESCRIPTION
## Summary

Adds `tools/branch-cleanup/` — a small utility to find and delete local git branches that are already merged, including **squash-merges** (which `git branch --merged` cannot detect on its own).

## Contents

- `prune-branches.ps1` — classifies every local branch as **merged** (obsolete) or **active**; dry-run by default, deletes only with `-Delete`.
- `prune-branches.bat` — thin launcher that forwards flags and picks pwsh 7 or Windows PowerShell 5.1.
- `README.md` — usage, classification rules, and requirements.

## How it detects merges

- `git branch --merged main` — catches true merge-commit / fast-forward branches.
- `gh pr list --state merged` (one batched call, 1000-PR window) — catches squash-merged branches by PR head name. This is the primary path for a squash-merge workflow.

## Safety

- The current branch and `main` are always protected.
- Misclassification only ever fails **safe**: an undetected merged branch is kept, never wrongly deleted.
- Deletion uses `git branch -D` since squash-merged branches aren't "merged" in git's eyes.

## Usage

```powershell
./tools/branch-cleanup/prune-branches.ps1            # dry run in current repo
./tools/branch-cleanup/prune-branches.ps1 -Delete    # delete merged branches
./tools/branch-cleanup/prune-branches.ps1 -Path C:\code\other-clone   # target another clone
```

## Requirements

git, PowerShell (5.1 ships with Windows), and `gh` authenticated — effectively required for squash workflows.