### PR TITLE
branch-cleanup: guard squash deletion against reused branch names

### DIFF
--- a/tools/branch-cleanup/README.md
+++ b/tools/branch-cleanup/README.md
@@ -8,9 +8,10 @@ GitHub squash-merges, which `git branch --merged` cannot detect on its own).
 Run from the root of a clone (operates on the current directory)...
 
 ```powershell
-./tools/branch-cleanup/prune-branches.ps1          # dry run: classify only
-./tools/branch-cleanup/prune-branches.ps1 -Delete  # delete the merged branches
-./tools/branch-cleanup/prune-branches.ps1 -Main master   # different base branch
+./tools/branch-cleanup/prune-branches.ps1                 # dry run: classify only
+./tools/branch-cleanup/prune-branches.ps1 -Delete         # delete the merged branches
+./tools/branch-cleanup/prune-branches.ps1 -Delete -Force  # also delete "needs review" branches
+./tools/branch-cleanup/prune-branches.ps1 -Main master    # different base branch
 ```
 
 ...or run it from anywhere and point it at a clone with `-Path`:
@@ -34,10 +35,16 @@ tools\branch-cleanup\prune-branches.bat -Delete
 - **Merged / obsolete:** the branch tip is reachable from `main`
   (`git branch --merged`) **or** GitHub reports a merged PR for it.
   The PR check is what catches squash-merges.
+- **Needs review:** a squash-merge is matched by branch *name*, so a new local
+  branch that reuses a merged branch's name would look merged. If such a
+  branch's tip commit is **newer** than the PR merge time, it is flagged and
+  **kept** — deleted only with `-Force`. This protects unpushed work on a
+  reused branch name.
 - **Active:** everything else — kept.
 
 Deletion uses `git branch -D` because squash-merged branches are not
 "merged" from git's point of view (their commits never land in `main`).
+Deleted refs remain recoverable via `git reflog` for ~30 days.
 
 ## Requirements
 

--- a/tools/branch-cleanup/prune-branches.ps1
+++ b/tools/branch-cleanup/prune-branches.ps1
@@ -9,8 +9,16 @@
 
   The current branch and the main branch are always protected.
 
+  Reused-name guard: a squash-merge is matched by branch name, so a new local
+  branch that reuses a merged branch's name would look merged. If such a
+  branch's tip commit is NEWER than the PR merge time, it is treated as
+  NEEDS REVIEW and kept unless -Force is given.
+
 .PARAMETER Delete
   Actually delete the merged branches (git branch -D). Without this flag, the script only reports.
+
+.PARAMETER Force
+  Also delete NEEDS REVIEW branches (tip newer than the merge). Off by default.
 
 .PARAMETER Main
   Name of the main/base branch. Defaults to 'main'.
@@ -19,15 +27,17 @@
   Path to the repo to operate on. Defaults to the current directory.
 
 .EXAMPLE
-  ./tools/branch-cleanup/prune-branches.ps1            # dry run in the current repo
-  ./tools/branch-cleanup/prune-branches.ps1 -Delete    # delete the merged branches
+  ./tools/branch-cleanup/prune-branches.ps1                 # dry run in the current repo
+  ./tools/branch-cleanup/prune-branches.ps1 -Delete         # delete the merged branches
+  ./tools/branch-cleanup/prune-branches.ps1 -Delete -Force  # also delete NEEDS REVIEW branches
   ./tools/branch-cleanup/prune-branches.ps1 -Path C:\code\other-clone   # target another clone
 #>
 [CmdletBinding()]
 param(
     [switch]$Delete,
     [string]$Main = 'main',
-    [string]$Path = '.'
+    [string]$Path = '.',
+    [switch]$Force
 )
 
 $ErrorActionPreference = 'Stop'
@@ -52,29 +62,45 @@ if (-not $hasGh) {
 $mergedByGit = @(git branch --merged $Main --format '%(refname:short)') |
     Where-Object { $_ -and $_ -ne $Main }
 
-# Head-branch names of merged PRs, fetched in one call (catches squash-merges).
-$mergedPrHeads = @()
+# Merged-PR head names + latest merge time, one call (catches squash-merges).
+$prMergedAt = @{}
 if ($hasGh) {
-    $mergedPrHeads = @(gh pr list --state merged --limit 1000 --json headRefName --jq '.[].headRefName')
+    $prs = gh pr list --state merged --limit 1000 --json headRefName,mergedAt | ConvertFrom-Json
+    foreach ($pr in $prs) {
+        $h    = $pr.headRefName
+        $when = [datetimeoffset]$pr.mergedAt
+        if (-not $prMergedAt.ContainsKey($h) -or $when -gt $prMergedAt[$h]) {
+            $prMergedAt[$h] = $when
+        }
+    }
 }
 
 $branches = @(git branch --format '%(refname:short)') |
     Where-Object { $_ -and $_ -ne $Main -and $_ -ne $current }
 
-$merged = [System.Collections.Generic.List[object]]::new()
-$active = [System.Collections.Generic.List[string]]::new()
+$merged     = [System.Collections.Generic.List[object]]::new()
+$suspicious = [System.Collections.Generic.List[object]]::new()
+$active     = [System.Collections.Generic.List[string]]::new()
 
 foreach ($b in $branches) {
-    $reason = $null
     if ($mergedByGit -contains $b) {
-        $reason = 'merged into main'
+        $merged.Add([pscustomobject]@{ Branch = $b; Reason = 'merged into main' })
     }
-    elseif ($mergedPrHeads -contains $b) {
-        $reason = 'merged via PR (squash)'
+    elseif ($prMergedAt.ContainsKey($b)) {
+        # Squash-merge match by name. Guard the reused-name case: if the tip
+        # commit post-dates the merge, the branch holds new work, not the
+        # merged work - flag it instead of deleting.
+        $tip = [datetimeoffset](git log -1 --format=%cI $b)
+        if ($tip -gt $prMergedAt[$b]) {
+            $suspicious.Add([pscustomobject]@{ Branch = $b; Reason = 'PR merged, but tip commit is NEWER - possible reused name' })
+        }
+        else {
+            $merged.Add([pscustomobject]@{ Branch = $b; Reason = 'merged via PR (squash)' })
+        }
     }
-
-    if ($reason) { $merged.Add([pscustomobject]@{ Branch = $b; Reason = $reason }) }
-    else         { $active.Add($b) }
+    else {
+        $active.Add($b)
+    }
 }
 
 Write-Host ""
@@ -86,19 +112,32 @@ Write-Host ""
 Write-Host "MERGED / obsolete: $($merged.Count)" -ForegroundColor Yellow
 $merged | ForEach-Object { Write-Host ("  {0,-55} {1}" -f $_.Branch, $_.Reason) }
 
+if ($suspicious.Count -gt 0) {
+    Write-Host ""
+    Write-Host "NEEDS REVIEW - kept unless -Force: $($suspicious.Count)" -ForegroundColor Red
+    $suspicious | ForEach-Object { Write-Host ("  {0,-55} {1}" -f $_.Branch, $_.Reason) }
+}
+
 if (-not $Delete) {
     Write-Host ""
     Write-Host "Dry run. Re-run with -Delete to remove the $($merged.Count) merged branch(es)." -ForegroundColor Cyan
     return
 }
 
-if ($merged.Count -eq 0) { Write-Host "`nNothing to delete." -ForegroundColor Green; return }
+$toDelete = [System.Collections.Generic.List[object]]::new()
+$toDelete.AddRange($merged)
+if ($Force) { $toDelete.AddRange($suspicious) }
+
+if ($toDelete.Count -eq 0) { Write-Host "`nNothing to delete." -ForegroundColor Green; return }
 
 Write-Host ""
-foreach ($m in $merged) {
+foreach ($m in $toDelete) {
     git branch -D $m.Branch
 }
-Write-Host "Deleted $($merged.Count) branch(es)." -ForegroundColor Green
+Write-Host "Deleted $($toDelete.Count) branch(es)." -ForegroundColor Green
+if ($suspicious.Count -gt 0 -and -not $Force) {
+    Write-Host "Kept $($suspicious.Count) needing review; re-run with -Force to delete those too." -ForegroundColor Yellow
+}
 
 }
 finally {


### PR DESCRIPTION
## Summary

Adds a safety guard to `tools/branch-cleanup/prune-branches.ps1` for the one hole in squash-merge detection: because a squash-merge is matched by branch **name**, a new local branch that reuses a previously-merged branch's name would be wrongly classified as merged and deleted — losing unpushed work.

## What changed

- The merged-PR lookup now also fetches `mergedAt` (still one `gh` call).
- For each squash-name match, the branch's tip commit time is compared to the PR merge time.
- If the tip is **newer** than the merge, the branch is classified **NEEDS REVIEW** and **kept** — deleted only with the new `-Force` flag.
- README + help updated; added note that `git branch -D` deletions are recoverable via `git reflog` for ~30 days.

## Classification now

- **Merged / obsolete** → deleted with `-Delete`.
- **Needs review** (squash name match but tip newer than merge) → kept unless `-Delete -Force`.
- **Active** / current / `main` → always kept.

## Verified locally

- Legit squash-merged branch (tip predates merge) → still classified merged and deleted.
- Branch with a post-merge tip commit → flagged NEEDS REVIEW, kept on `-Delete`, removed only with `-Force`.

Follow-up to #1065.