### PR TITLE
chore: commit .vscodeclaude_session.json gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ memory/
 # VSCodeClaude session files (auto-generated)
 .vscodeclaude_status.txt
 .vscodeclaude_analysis.json
+.vscodeclaude_session.json
 .vscodeclaude_start.bat
 .vscodeclaude_start.sh
 


### PR DESCRIPTION
## Summary

Commit the `.vscodeclaude_session.json` gitignore entry so vscodeclaude session launches stop leaving `.gitignore` modified in every session clone.

- The file is the typed SessionSpec introduced in #1019, written at every session launch; `update_gitignore()` appended the missing entry to `.gitignore` on each launch, but only inside the throwaway clone.
- The entry is placed inside the existing `# VSCodeClaude session files (auto-generated)` block (matching `GITIGNORE_ENTRY` order), instead of the auto-appended dangling line at the file end.
- Sibling repos are covered by chores in their chore list issues; the `mcp-coder init` extension for new repos is tracked in #1087.

Closes #1086
