### PR TITLE
docs: forbid AskUserQuestion tool in CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -122,6 +122,10 @@ This repo uses `mcp-coder-utils` for subprocess execution, logging, and redactio
 
 Be concise. If one line works, don't use three.
 
+## Asking questions
+
+Never use the AskUserQuestion tool. Ask questions as plain text in the chat.
+
 ## Obsidian knowledge base
 
 An Obsidian vault (`obsidian-dev-wiki`) is available via the `obsidian-wiki` MCP server.


### PR DESCRIPTION
Adds an "Asking questions" section to `.claude/CLAUDE.md`: never use the AskUserQuestion tool; ask questions as plain chat text, one at a time, with full context and simple A/B/C options.

The tool's UI truncates question context, making options hard to evaluate.