### PR TITLE
docs: document automated review workflows

### DIFF
--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -458,7 +458,7 @@ The workflow code is layered into three tiers, enforced by the import-linter `La
 
 ### Architectural Boundary Enforcement
 - **Tools**: import-linter, tach, pycycle for static analysis of module dependencies; vulture for dead code detection
-- **Configuration**: `.importlinter` (22 contracts), `tach.toml` (layer definitions)
+- **Configuration**: `.importlinter` (20 contracts), `tach.toml` (layer definitions)
 - **CI Integration**: Architecture checks run automatically on pull requests
 - **Documentation**: See `docs/architecture/dependencies/README.md` for detailed tool comparison, current contracts, and guidelines for adding new rules
 - **Visualization**: `docs/architecture/dependencies/dependency_graph.html` for interactive dependency graph

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -290,6 +290,20 @@ Interactive terminal chat for LLM-assisted coding. Three-layer architecture maxi
   - `prerequisites.py` - Git status and prerequisite validation
   - `task_processing.py` - Individual task processing, mypy checks, formatting
   - **CLI Integration**: Accessible via `cli/commands/implement.py`
+- **Automated review workflows**: `workflows/review/` - Shared engine behind `mcp-coder review-plan` and `review-implementation` (tests: `workflows/review/test_*.py`)
+  - `core.py` - Multi-round review loop (fresh reviewer session per round + persistent supervisor session, rounds cap 5), 3-way outcome routing
+  - `config.py` - `ReviewConfig` (`REVIEW_PLAN` / `REVIEW_IMPLEMENTATION`) parameterizing the shared engine
+  - `verdict.py` - Strict fenced-JSON supervisor verdict parser (`dismiss` / `tasks` / `escalate`)
+  - `review_log.py` - Per-round `pr_info/*_review_log_{n}.md` logging
+  - **Optional & config-gated**: dispatched only when `auto_review_plan` / `auto_review_implementation` are enabled (default off)
+
+#### Three-tier workflow architecture
+
+The workflow code is layered into three tiers, enforced by the import-linter `Layered Architecture` contract and `tach.toml`:
+
+- **`workflows/`** (top) - Thin orchestrators. Each owns its labels, config, and `FailureCategory`, and sequences steps.
+- **`workflow_steps/`** (middle) - Workflow-agnostic composed steps (commit/push, rebase, CI check-and-fix, prerequisite checks) shared across `implement` and the review workflows. Sits **above** `checks` so a step may compose a `check` (e.g. CI summary).
+- **`workflow_utils/`** + **`checks/`** (primitives) - Single-purpose capabilities (`task_tracker`, `commit_operations`, `base_branch`, `label_transitions`, `failure_handling`) and branch/CI assessments. `workflow_utils` stays a pure primitive layer with only downward imports.
 
 ---
 
@@ -444,7 +458,7 @@ Interactive terminal chat for LLM-assisted coding. Three-layer architecture maxi
 
 ### Architectural Boundary Enforcement
 - **Tools**: import-linter, tach, pycycle for static analysis of module dependencies; vulture for dead code detection
-- **Configuration**: `.importlinter` (19 contracts), `tach.toml` (layer definitions)
+- **Configuration**: `.importlinter` (22 contracts), `tach.toml` (layer definitions)
 - **CI Integration**: Architecture checks run automatically on pull requests
 - **Documentation**: See `docs/architecture/dependencies/README.md` for detailed tool comparison, current contracts, and guidelines for adding new rules
 - **Visualization**: `docs/architecture/dependencies/dependency_graph.html` for interactive dependency graph

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -9,6 +9,7 @@ Core commands for help, verification, and interactive prompts.
 
 | Command | Description |
 |---------|-------------|
+| [`init`](#init) | Initialize project: create config and deploy Claude skills |
 | [`help`](#help) | Show comprehensive help information with examples |
 | [`verify`](#verify) | Verify Claude CLI installation and configuration |
 | [`prompt`](#prompt) | Execute prompt via Claude API with configurable debug output |
@@ -26,7 +27,10 @@ End-to-end development automation from planning to pull requests.
 | Command | Description |
 |---------|-------------|
 | [`create-plan`](#create-plan) | Generate implementation plan for a GitHub issue |
+| [`review-plan`](#review-plan) | Run automated review of an implementation plan |
 | [`implement`](#implement) | Execute implementation workflow from task tracker |
+| [`rebase`](#rebase) | Automatically rebase the current branch onto its base branch |
+| [`review-implementation`](#review-implementation) | Run automated review of an implementation |
 | [`create-pr`](#create-pr) | Create pull request with AI-generated summary |
 
 ### Interactive Development
@@ -59,6 +63,7 @@ GitHub repository utilities for branch detection and workflow automation.
 
 | Command | Description |
 |---------|-------------|
+| [`gh-tool checkout-issue-branch`](#gh-tool-checkout-issue-branch) | Checkout or create a branch linked to a GitHub issue |
 | [`gh-tool get-base-branch`](#gh-tool-get-base-branch) | Detect base branch for current feature branch |
 | [`gh-tool define-labels`](#gh-tool-define-labels) | Sync workflow status labels to GitHub repository |
 | [`gh-tool issue-stats`](#gh-tool-issue-stats) | Display issue statistics grouped by workflow status category |
@@ -83,6 +88,34 @@ mcp-coder help                         # Show comprehensive help with examples (
 ---
 
 ## Commands
+
+### init
+
+Initialize a project for MCP Coder: create the user config file (if missing) and deploy the bundled Claude Code skills into the project.
+
+```bash
+mcp-coder init [OPTIONS]
+```
+
+**Options:**
+- `--project-dir PATH` - Target project directory (default: current directory)
+- `--just-skills` - Deploy skills only, skip config creation
+
+**Description:** Bootstraps a project so the automated workflows and interactive tools can run: writes a starter user configuration and installs the `.claude/skills/` slash-command skills. Use `--just-skills` to refresh only the deployed skills without touching config.
+
+**Examples:**
+```bash
+# Initialize the current project (config + skills)
+mcp-coder init
+
+# Refresh deployed skills only
+mcp-coder init --just-skills
+
+# Initialize a specific project directory
+mcp-coder init --project-dir /path/to/project
+```
+
+---
 
 ### help
 
@@ -314,6 +347,67 @@ mcp-coder create-plan 789 --project-dir /path/to/project
 
 ---
 
+### review-plan
+
+Run automated review of an implementation plan.
+
+```bash
+mcp-coder review-plan [OPTIONS]
+```
+
+**Options:**
+- `--project-dir PATH` - Project directory path (default: current directory)
+- `--llm-method METHOD` - LLM provider: `claude` (default), `copilot`, or `langchain`
+- `--mcp-config PATH` - Path to MCP configuration file
+- `--settings PATH` - Path to Claude Code settings file (e.g., `.claude/settings.local.json`). Forwarded to Claude via its `--settings` flag; overrides cwd-based settings discovery. Auto-detected from `<project_dir>/.claude/` if omitted. See [Configuration Guide](configuration/config.md#claude).
+- `--execution-dir PATH` - Working directory for Claude subprocess
+- `--update-issue-labels` / `--no-update-issue-labels` - Update GitHub issue labels on success/failure (default: from config.toml, or false)
+- `--post-issue-comments` / `--no-post-issue-comments` - Post GitHub comments on workflow failure (default: from config.toml, or false)
+
+**Description:** Automatically review the implementation plan on the current branch. The issue number is derived from the branch (no positional argument). A multi-round loop pairs a fresh reviewer session each round with a persistent supervisor session (rounds cap: 5) and ends in a 3-way decision: **success** advances the issue to `status-05:plan-ready`; **needs-human** routes to `status-04:plan-review` for the interactive supervisor; **error** sets a `status-14f-*` failure label. Each round appends to `pr_info/plan_review_log_{n}.md`. Requires `auto_review_plan = true` for the coordinator to dispatch it; otherwise run manually.
+
+**Examples:**
+```bash
+# Review the plan on the current branch
+mcp-coder review-plan
+
+# Update labels and post comments on the outcome
+mcp-coder review-plan --update-issue-labels --post-issue-comments
+```
+
+---
+
+### rebase
+
+Automatically rebase the current branch onto its base branch.
+
+```bash
+mcp-coder rebase [OPTIONS]
+```
+
+**Options:**
+- `--project-dir PATH` - Project directory path (default: current directory)
+- `--llm-method METHOD` - LLM provider: `claude` (default), `copilot`, or `langchain`
+- `--mcp-config PATH` - Path to MCP configuration file
+- `--settings PATH` - Path to Claude Code settings file (e.g., `.claude/settings.local.json`). Forwarded to Claude via its `--settings` flag; overrides cwd-based settings discovery. Auto-detected from `<project_dir>/.claude/` if omitted. See [Configuration Guide](configuration/config.md#claude).
+- `--execution-dir PATH` - Working directory for Claude subprocess
+- `--base-branch BRANCH` - Base branch to rebase onto (default: auto-detect; required for non-main/master bases)
+
+**Description:** Rebase the current feature branch onto its base branch, resolving conflicts with LLM assistance where needed. The base branch is auto-detected unless `--base-branch` is given (required when the base is not `main`/`master`). This is the same rebase step the `review-implementation` workflow runs between rounds.
+
+**Exit codes:** `0` = success or no-op (already current); `1` = aborted / needs human; `2` = error (bad repo/args, push rejected).
+
+**Examples:**
+```bash
+# Rebase onto the auto-detected base branch
+mcp-coder rebase
+
+# Rebase onto an explicit base branch
+mcp-coder rebase --base-branch develop
+```
+
+---
+
 ### create-pr
 
 Create pull request with AI-generated summary.
@@ -350,6 +444,36 @@ mcp-coder create-pr --update-issue-labels --post-issue-comments
 
 ---
 
+### review-implementation
+
+Run automated review of an implementation.
+
+```bash
+mcp-coder review-implementation [OPTIONS]
+```
+
+**Options:**
+- `--project-dir PATH` - Project directory path (default: current directory)
+- `--llm-method METHOD` - LLM provider: `claude` (default), `copilot`, or `langchain`
+- `--mcp-config PATH` - Path to MCP configuration file
+- `--settings PATH` - Path to Claude Code settings file (e.g., `.claude/settings.local.json`). Forwarded to Claude via its `--settings` flag; overrides cwd-based settings discovery. Auto-detected from `<project_dir>/.claude/` if omitted. See [Configuration Guide](configuration/config.md#claude).
+- `--execution-dir PATH` - Working directory for Claude subprocess
+- `--update-issue-labels` / `--no-update-issue-labels` - Update GitHub issue labels on success/failure (default: from config.toml, or false)
+- `--post-issue-comments` / `--no-post-issue-comments` - Post GitHub comments on workflow failure (default: from config.toml, or false)
+
+**Description:** Automatically review the implemented code on the current branch. The issue number is derived from the branch (no positional argument). A multi-round loop pairs a fresh reviewer session each round with a persistent supervisor session (rounds cap: 5), applies fixes via MCP edit tools, and re-runs the shared rebase/CI steps between rounds. It ends in a 3-way decision: **success** advances the issue to `status-08:ready-pr`; **needs-human** routes to `status-07:code-review` for the interactive supervisor; **error** sets a `status-17f-*` failure label (`status-17f-ci:code-review-ci-fix-needed` when CI is still red at the rounds cap). Each round appends to `pr_info/implementation_review_log_{n}.md`. Requires `auto_review_implementation = true` for the coordinator to dispatch it; otherwise run manually.
+
+**Examples:**
+```bash
+# Review the implementation on the current branch
+mcp-coder review-implementation
+
+# Update labels and post comments on the outcome
+mcp-coder review-implementation --update-issue-labels --post-issue-comments
+```
+
+---
+
 ### coordinator
 
 Monitor and dispatch workflows for GitHub issues.
@@ -366,7 +490,7 @@ mcp-coder coordinator (--all | --repo REPO_NAME) [OPTIONS]
 - `--dry-run` - Trigger Jenkins integration test for repository
 - `--force-refresh` - Force full cache refresh, bypass all caching
 
-**Description:** Monitor GitHub issues and automatically dispatch workflows (create-plan, implement, create-pr) based on issue labels and status.
+**Description:** Monitor GitHub issues and automatically dispatch workflows (create-plan, implement, create-pr, and the optional review-plan / review-implementation) based on issue labels and status.
 
 **Examples:**
 ```bash
@@ -726,6 +850,35 @@ mcp-coder check file-size --allowlist-file .my-allowlist
 - **CI/CD Integration:** Add to pre-commit hooks or CI pipelines to enforce file size limits
 - **Codebase Cleanup:** Identify large files that may need refactoring
 - **Gradual Adoption:** Use `--generate-allowlist` to create an allowlist of existing large files, then enforce limits on new files
+
+---
+
+### gh-tool checkout-issue-branch
+
+Checkout or create a branch linked to a GitHub issue.
+
+```bash
+mcp-coder gh-tool checkout-issue-branch ISSUE_NUMBER [OPTIONS]
+```
+
+**Arguments:**
+- `issue_number` - GitHub issue number (required)
+
+**Options:**
+- `--project-dir PATH` - Project directory path (default: current directory)
+
+**Description:** Checkout the branch linked to the given GitHub issue, creating it if it does not yet exist. Used by the automated workflows to land on the correct branch for an issue before running.
+
+**Exit codes:** `0` = success (branch checked out); `1` = could not find or create branch; `2` = error (not a git repo, API failure).
+
+**Examples:**
+```bash
+# Checkout (or create) the branch for issue #123
+mcp-coder gh-tool checkout-issue-branch 123
+
+# Target a specific project directory
+mcp-coder gh-tool checkout-issue-branch 123 --project-dir /path/to/project
+```
 
 ---
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -91,7 +91,7 @@ mcp-coder help                         # Show comprehensive help with examples (
 
 ### init
 
-Initialize a project for MCP Coder: create the user config file (if missing) and deploy the bundled Claude Code skills into the project.
+Initialize a project for MCP Coder: create the user config file (if missing) and deploy the bundled Claude Code resources (skills, knowledge base, and agents) into the project.
 
 ```bash
 mcp-coder init [OPTIONS]
@@ -99,16 +99,16 @@ mcp-coder init [OPTIONS]
 
 **Options:**
 - `--project-dir PATH` - Target project directory (default: current directory)
-- `--just-skills` - Deploy skills only, skip config creation
+- `--just-skills` - Deploy the bundled resources only (skills, knowledge base, and agents, despite the name), skip config creation
 
-**Description:** Bootstraps a project so the automated workflows and interactive tools can run: writes a starter user configuration and installs the `.claude/skills/` slash-command skills. Use `--just-skills` to refresh only the deployed skills without touching config.
+**Description:** Bootstraps a project so the automated workflows and interactive tools can run: writes a starter user configuration and installs the bundled Claude Code resources into `.claude/` — `.claude/skills/`, `.claude/knowledge_base/`, and `.claude/agents/`. Use `--just-skills` to refresh only the deployed resources (all three sets, despite the name) without touching config.
 
 **Examples:**
 ```bash
-# Initialize the current project (config + skills)
+# Initialize the current project (config + bundled resources)
 mcp-coder init
 
-# Refresh deployed skills only
+# Refresh deployed resources only (skills, knowledge base, agents)
 mcp-coder init --just-skills
 
 # Initialize a specific project directory

--- a/docs/configuration/config.md
+++ b/docs/configuration/config.md
@@ -63,16 +63,19 @@ The auto-created template includes all sections with example values:
 # MCP Coder Configuration
 # Update with your actual credentials and repository information
 
-[coordinator]
-# GitHub API caching settings (optional)
-# Controls how long to cache GitHub API responses before refreshing
-# Reduces API calls and improves performance for subsequent runs
-cache_refresh_minutes = 1440  # 24 hours (default)
+# [llm]
+# Default LLM provider: "claude" (default), "copilot", or "langchain"
+# default_provider = "copilot"
 
-# Alternative cache durations based on your needs:
-# cache_refresh_minutes = 60    # 1 hour - for active development
-# cache_refresh_minutes = 360   # 6 hours - balanced approach
-# cache_refresh_minutes = 2880  # 48 hours - for stable repositories
+# [mcp]
+# Default MCP config file path (relative to CWD or absolute)
+# Environment variable (higher priority): MCP_CODER_MCP_CONFIG
+# default_config_path = ".mcp.json"
+
+[github]
+# GitHub authentication
+# Environment variable (higher priority): GITHUB_TOKEN
+token = "ghp_your_github_personal_access_token_here"
 
 [jenkins]
 # Jenkins server configuration
@@ -80,29 +83,50 @@ cache_refresh_minutes = 1440  # 24 hours (default)
 server_url = "https://jenkins.example.com:8080"
 username = "your-jenkins-username"
 api_token = "your-jenkins-api-token"
-# The Jenkins variables can be also configured as environment variables:
-# - JENKINS_URL
-# - JENKINS_USER
-# - JENKINS_TOKEN
+test_job = "Tests/mcp-coder-simple-test"  # Job for integration tests
+test_job_coordination = "Tests/mcp-coder-coordinator-test"  # Job for coordinator tests
 
-# Coordinator repositories
+# Coordinator test repositories
 # Add your repositories here following this pattern
 
-[coordinator.repos.repo_a]
-repo_url = "https://github.com/your-org/repo_a.git"
-executor_job_path = "jenkins_folder_a/test-job-a"
+[coordinator.repos.mcp_coder]
+repo_url = "https://github.com/your-org/mcp_coder.git"
+executor_job_path = "Tests/mcp-coder-coordinator-test"
 github_credentials_id = "github-general-pat"
+# executor_os: "windows" or "linux" (default: "linux", case-insensitive)
+# Use "windows" for Windows Jenkins executors, "linux" for Linux/container executors
+executor_os = "linux"
+update_issue_labels = true
+post_issue_comments = true
 
-[coordinator.repos.repo_b]
-repo_url = "https://github.com/your-org/repo_b.git"
-executor_job_path = "jenkins_folder_b/test-job-b"
+[coordinator.repos.mcp_workspace]
+repo_url = "https://github.com/your-org/mcp-workspace.git"
+executor_job_path = "Tests/mcp-workspace-coordinator-test"
 github_credentials_id = "github-general-pat"
+executor_os = "linux"
+update_issue_labels = true
+post_issue_comments = true
+
+# Example Windows executor configuration:
+# [coordinator.repos.windows_project]
+# repo_url = "https://github.com/your-org/windows-app.git"
+# executor_job_path = "Windows/Executor/Test"
+# github_credentials_id = "github-general-pat"
+# executor_os = "windows"
+# update_issue_labels = true
+# post_issue_comments = true
 
 # Add more repositories as needed:
 # [coordinator.repos.your_repo_name]
 # repo_url = "https://github.com/your-org/your_repo.git"
-# executor_job_path = "Folder/job-name"
+# executor_job_path = "Tests/your-repo-coordinator-test"
 # github_credentials_id = "github-credentials-id"
+# executor_os = "linux"
+
+[vscodeclaude]
+# VSCodeClaude session configuration
+# workspace_base = "C:/path/to/vscodeclaude/workspaces"
+# max_sessions = 3
 ```
 
 ## Configuration Sections
@@ -252,29 +276,31 @@ default_settings_path = ".claude/settings.local.json"
 
 Selects the LLM provider. Defaults to `"claude"` when omitted.
 
+Resolution order (highest priority first): the `--llm-method` CLI flag, the `MCP_CODER_LLM_PROVIDER` environment variable, `[llm] default_provider` in config, then the `"claude"` default.
+
 | Field | Type | Description | Required | Default |
 |-------|------|-------------|----------|---------|
-| `provider` | string | LLM provider: `"claude"`, `"copilot"`, or `"langchain"` | No | `"claude"` |
+| `default_provider` | string | LLM provider: `"claude"`, `"copilot"`, or `"langchain"` | No | `"claude"` |
 
 **Example — use Claude (default, no change needed):**
 
 ```toml
 [llm]
-provider = "claude"
+default_provider = "claude"
 ```
 
 **Example — use Copilot CLI:**
 
 ```toml
 [llm]
-provider = "copilot"
+default_provider = "copilot"
 ```
 
 **Example — use LangChain:**
 
 ```toml
 [llm]
-provider = "langchain"
+default_provider = "langchain"
 ```
 
 **Ad-hoc provider selection:** Any command with `--llm-method` supports all providers without changing config:
@@ -286,7 +312,7 @@ mcp-coder implement --llm-method copilot
 
 ### [llm.langchain]
 
-LangChain backend configuration. Required when `[llm] provider = "langchain"`.
+LangChain backend configuration. Required when `[llm] default_provider = "langchain"`.
 
 Install the extra dependency first:
 
@@ -313,7 +339,7 @@ extras (smaller footprints if you only need one backend).
 
 ```toml
 [llm]
-provider = "langchain"
+default_provider = "langchain"
 
 [llm.langchain]
 backend  = "openai"
@@ -335,7 +361,7 @@ api_key  = "..."                    # or OPENAI_API_KEY env var
 
 ```toml
 [llm]
-provider = "langchain"
+default_provider = "langchain"
 
 [llm.langchain]
 backend  = "gemini"
@@ -347,7 +373,7 @@ api_key  = "..."          # or set GEMINI_API_KEY env var
 
 ```toml
 [llm]
-provider = "langchain"
+default_provider = "langchain"
 
 [llm.langchain]
 backend     = "openai"
@@ -361,7 +387,7 @@ api_key     = "..."
 
 ```toml
 [llm]
-provider = "langchain"
+default_provider = "langchain"
 
 [llm.langchain]
 backend  = "anthropic"
@@ -373,7 +399,7 @@ api_key  = "sk-ant-..."   # or set ANTHROPIC_API_KEY env var
 
 ```toml
 [llm]
-provider = "langchain"
+default_provider = "langchain"
 
 [llm.langchain]
 backend  = "ollama"
@@ -470,10 +496,13 @@ Each repository needs its own nested section: `[coordinator.repos.repo_name]`
 | `repo_url` | string | Git repository HTTPS URL | Yes | — |
 | `executor_job_path` | string | Jenkins job path (folder/job-name) | Yes | — |
 | `github_credentials_id` | string | Jenkins GitHub credentials ID (see setup below) | Yes | — |
+| `executor_os` | string | Executor platform: `"windows"` or `"linux"` (case-insensitive) | No | `"linux"` |
 | `update_issue_labels` | boolean | Update GitHub issue labels on workflow success/failure | No | `false` |
 | `post_issue_comments` | boolean | Post GitHub comments on workflow failure | No | `false` |
 | `auto_review_plan` | boolean | Gate automated plan review (routes create-plan success to `status-14:plan-review-bot` for coordinator pickup). | No | `false` |
 | `auto_review_implementation` | boolean | Gate automated implementation review (routes implement success to `status-17:code-review-bot` for coordinator pickup). | No | `false` |
+| `setup_commands_windows` | list | Shell commands run during environment setup on Windows executors | No | — |
+| `setup_commands_linux` | list | Shell commands run during environment setup on Linux executors | No | — |
 
 **Example:**
 
@@ -544,6 +573,7 @@ Environment variables take **highest priority** over config file values.
 | `JENKINS_URL` | `[jenkins] server_url` | `https://jenkins.local:8080` |
 | `JENKINS_USER` | `[jenkins] username` | `automation-user` |
 | `JENKINS_TOKEN` | `[jenkins] api_token` | `abc123def456...` |
+| `MCP_CODER_LLM_PROVIDER` | `[llm] default_provider` | `claude` |
 
 **Usage:**
 

--- a/docs/configuration/config.md
+++ b/docs/configuration/config.md
@@ -5,7 +5,7 @@ Complete configuration documentation for MCP Coder, covering user configuration 
 ## Quick Reference
 
 | Topic | Location |
-|-------|----------|
+| ------- | ---------- |
 | **User Config** | `~/.mcp_coder/config.toml` (Linux/macOS)<br>`%USERPROFILE%\.mcp_coder\config.toml` (Windows) |
 | **Environment Variables** | `JENKINS_URL`, `JENKINS_USER`, `JENKINS_TOKEN` |
 | **LLM Provider** | `[llm]` section in `config.toml` |
@@ -30,6 +30,7 @@ MCP Coder uses two separate configuration files for different purposes:
 ## Configuration File Locations
 
 ### Windows
+
 ```
 %USERPROFILE%\.mcp_coder\config.toml
 ```
@@ -37,6 +38,7 @@ MCP Coder uses two separate configuration files for different purposes:
 Example: `C:\Users\YourName\.mcp_coder\config.toml`
 
 ### Linux / macOS / Containers
+
 ```
 ~/.mcp_coder/config.toml
 ```
@@ -116,24 +118,28 @@ Coordinator-specific settings for GitHub API optimization and caching.
 #### Configuration Examples
 
 **Default Configuration (24-hour refresh):**
+
 ```toml
 [coordinator]
 cache_refresh_minutes = 1440  # 24 hours (default)
 ```
 
 **Active Development (1-hour refresh):**
+
 ```toml
 [coordinator]
 cache_refresh_minutes = 60  # 1 hour - for repositories with frequent changes
 ```
 
 **Conservative Refresh (48-hour refresh):**
+
 ```toml
 [coordinator]
 cache_refresh_minutes = 2880  # 48 hours - for stable repositories
 ```
 
 **Custom Refresh (6-hour refresh):**
+
 ```toml
 [coordinator]
 cache_refresh_minutes = 360  # 6 hours - balanced approach
@@ -142,7 +148,7 @@ cache_refresh_minutes = 360  # 6 hours - balanced approach
 #### Recommended Values by Use Case
 
 | Use Case | Recommended Value | Rationale |
-|----------|------------------|-----------|
+| ---------- | ------------------ | ----------- |
 | **Active Development** | `60` (1 hour) | Frequent issue updates, labels, assignments |
 | **Regular Development** | `1440` (24 hours) | Default balance of freshness and performance |
 | **Stable Projects** | `2880` (48 hours) | Minimal changes, maximize cache benefits |
@@ -150,6 +156,7 @@ cache_refresh_minutes = 360  # 6 hours - balanced approach
 | **Demo Environments** | `4320` (72 hours) | Infrequent changes, optimize for performance |
 
 #### Cache Behavior
+
 - GitHub API calls are cached to reduce API rate limiting
 - Issues are fetched incrementally using `since` parameter
 - Cache files are stored per repository in `~/.mcp_coder/cache/`
@@ -158,6 +165,7 @@ cache_refresh_minutes = 360  # 6 hours - balanced approach
 - Cache bypass available with `--force-refresh` flag
 
 #### Performance Benefits
+
 - Reduces GitHub API calls by 70-90% for subsequent runs
 - Faster coordinator execution on large repositories
 - Respects GitHub API rate limits
@@ -175,17 +183,20 @@ Configures the default MCP (Model Context Protocol) configuration file path. Whe
 **Resolution priority:** CLI `--mcp-config` arg > `MCP_CODER_MCP_CONFIG` env var > `[mcp] default_config_path` config > auto-detect
 
 **Relative path resolution (uniform across all four sources):**
+
 - Absolute path → used as-is.
 - Relative path → resolved against `--project-dir`.
 - When `--project-dir` is not provided → relative paths fall back to CWD.
 
 **Error behavior:**
+
 - **CLI arg** (`--mcp-config`): strict — raises `FileNotFoundError` if file not found
 - **Env var / config**: lenient — logs warning with source, falls back to auto-detect
 
 **Example:**
 
 The same relative path works from any working directory when `--project-dir` is set:
+
 ```bash
 # Resolves to <repo>/.mcp.json regardless of CWD
 mcp-coder implement --project-dir /workspace/repo --mcp-config .mcp.json
@@ -217,12 +228,14 @@ project directory.
 **Relative path resolution** mirrors `--mcp-config`: absolute paths are used as-is; relative paths resolve against `--project-dir`, falling back to CWD when `--project-dir` is not provided.
 
 **Error behavior:**
+
 - **CLI arg** (`--settings`): strict — raises `FileNotFoundError` if file not found
 - **Env var / config**: lenient — logs warning with source, falls back to auto-detect
 
 **Example:**
 
 The same relative path works from any working directory when `--project-dir` is set:
+
 ```bash
 # Resolves to <repo>/.claude/settings.local.json regardless of CWD
 mcp-coder implement --project-dir /workspace/repo --settings .claude/settings.local.json
@@ -244,24 +257,28 @@ Selects the LLM provider. Defaults to `"claude"` when omitted.
 | `provider` | string | LLM provider: `"claude"`, `"copilot"`, or `"langchain"` | No | `"claude"` |
 
 **Example — use Claude (default, no change needed):**
+
 ```toml
 [llm]
 provider = "claude"
 ```
 
 **Example — use Copilot CLI:**
+
 ```toml
 [llm]
 provider = "copilot"
 ```
 
 **Example — use LangChain:**
+
 ```toml
 [llm]
 provider = "langchain"
 ```
 
 **Ad-hoc provider selection:** Any command with `--llm-method` supports all providers without changing config:
+
 ```bash
 mcp-coder prompt "Your prompt" --llm-method copilot
 mcp-coder implement --llm-method copilot
@@ -272,6 +289,7 @@ mcp-coder implement --llm-method copilot
 LangChain backend configuration. Required when `[llm] provider = "langchain"`.
 
 Install the extra dependency first:
+
 ```bash
 pip install 'mcp-coder[langchain]'
 ```
@@ -280,7 +298,7 @@ See [`optional-dependencies.md`](./optional-dependencies.md) for per-provider
 extras (smaller footprints if you only need one backend).
 
 | Field | Type | Description | Required |
-|-------|------|-------------|----------|
+| ------- | ------ | ------------- | ---------- |
 | `backend` | string | LangChain backend: `"openai"`, `"gemini"`, `"anthropic"`, or `"ollama"` | Yes |
 | `model` | string | Model name (e.g. `"gpt-4o"`, `"gemini-1.5-pro"`). Doubles as `azure_deployment` for Azure | Yes |
 | `api_key` | string | API key (env var takes priority — see below) | No |
@@ -292,6 +310,7 @@ extras (smaller footprints if you only need one backend).
 > produces a doubled path and a `404 - {'detail': 'Not Found'}`.
 
 **Example — OpenAI GPT-4o:**
+
 ```toml
 [llm]
 provider = "langchain"
@@ -303,6 +322,7 @@ api_key  = "sk-..."       # or set OPENAI_API_KEY env var
 ```
 
 **Example — OpenAI-compatible relay:**
+
 ```toml
 [llm.langchain]
 backend  = "openai"
@@ -312,6 +332,7 @@ api_key  = "..."                    # or OPENAI_API_KEY env var
 ```
 
 **Example — Google Gemini:**
+
 ```toml
 [llm]
 provider = "langchain"
@@ -323,6 +344,7 @@ api_key  = "..."          # or set GEMINI_API_KEY env var
 ```
 
 **Example — Azure OpenAI:**
+
 ```toml
 [llm]
 provider = "langchain"
@@ -336,6 +358,7 @@ api_key     = "..."
 ```
 
 **Example — Anthropic Claude:**
+
 ```toml
 [llm]
 provider = "langchain"
@@ -347,6 +370,7 @@ api_key  = "sk-ant-..."   # or set ANTHROPIC_API_KEY env var
 ```
 
 **Example — Local Ollama (native backend):**
+
 ```toml
 [llm]
 provider = "langchain"
@@ -380,7 +404,7 @@ model    = "llama3:latest"
 Environment variables take **highest priority** over config file values.
 
 | Environment Variable | Overrides | Backend |
-|---------------------|-----------|---------|
+| --------------------- | ----------- | --------- |
 | `OPENAI_API_KEY` | `[llm.langchain] api_key` | `openai` |
 | `GEMINI_API_KEY` | `[llm.langchain] api_key` | `gemini` |
 | `ANTHROPIC_API_KEY` | `[llm.langchain] api_key` | `anthropic` |
@@ -390,6 +414,7 @@ Environment variables take **highest priority** over config file values.
 | `MCP_CODER_CLAUDE_SETTINGS` | `[claude] default_settings_path` | `.claude/settings.local.json` |
 
 **Usage in CI/CD:**
+
 ```bash
 export OPENAI_API_KEY="sk-prod-key"
 mcp-coder prompt "Summarise this PR"
@@ -411,12 +436,13 @@ history server-side).
 Jenkins server credentials for job automation.
 
 | Field | Type | Description | Required |
-|-------|------|-------------|----------|
+| ------- | ------ | ------------- | ---------- |
 | `server_url` | string | Jenkins server URL with port | Yes |
 | `username` | string | Jenkins username | Yes |
 | `api_token` | string | Jenkins API token (not password) | Yes |
 
 **Example:**
+
 ```toml
 [jenkins]
 server_url = "https://jenkins.company.com:8080"
@@ -425,6 +451,7 @@ api_token = "11a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5"
 ```
 
 **How to get API token:**
+
 1. Log into Jenkins web UI
 2. Click your name (top right) → Configure
 3. Under "API Token", click "Add new Token"
@@ -439,7 +466,7 @@ Each repository needs its own nested section: `[coordinator.repos.repo_name]`
 **Note:** These are nested TOML sections using dot notation. The configuration system supports accessing nested sections like `coordinator.repos.mcp_coder` to retrieve values from the `[coordinator.repos.mcp_coder]` section
 
 | Field | Type | Description | Required | Default |
-|-------|------|-------------|----------|---------|
+| ------- | ------ | ------------- | ---------- | --------- |
 | `repo_url` | string | Git repository HTTPS URL | Yes | — |
 | `executor_job_path` | string | Jenkins job path (folder/job-name) | Yes | — |
 | `github_credentials_id` | string | Jenkins GitHub credentials ID (see setup below) | Yes | — |
@@ -449,6 +476,7 @@ Each repository needs its own nested section: `[coordinator.repos.repo_name]`
 | `auto_review_implementation` | boolean | Gate automated implementation review (routes implement success to `status-17:code-review-bot` for coordinator pickup). | No | `false` |
 
 **Example:**
+
 ```toml
 [coordinator.repos.my_project]
 repo_url = "https://github.com/myorg/my_project.git"
@@ -456,9 +484,12 @@ executor_job_path = "MyProject/integration-tests"
 github_credentials_id = "github-pat-token"
 update_issue_labels = true
 post_issue_comments = true
+auto_review_plan = true
+auto_review_implementation = true
 ```
 
 **Repository naming:**
+
 - Use lowercase with underscores (e.g., `mcp_coder`, `my_project`)
 - Must match the repo_name used in CLI commands
 - Can be different from actual GitHub repo name
@@ -498,6 +529,7 @@ github_credentials_id = "github-general-pat"  # ← The ID from Jenkins
 ```
 
 **Security Notes:**
+
 - Use descriptive but not sensitive credential IDs
 - Regularly rotate GitHub tokens
 - Use minimum required token scopes
@@ -508,12 +540,13 @@ github_credentials_id = "github-general-pat"  # ← The ID from Jenkins
 Environment variables take **highest priority** over config file values.
 
 | Environment Variable | Overrides | Example |
-|---------------------|-----------|---------|
+| --------------------- | ----------- | --------- |
 | `JENKINS_URL` | `[jenkins] server_url` | `https://jenkins.local:8080` |
 | `JENKINS_USER` | `[jenkins] username` | `automation-user` |
 | `JENKINS_TOKEN` | `[jenkins] api_token` | `abc123def456...` |
 
 **Usage:**
+
 ```bash
 # Override all Jenkins config via environment
 export JENKINS_URL="https://jenkins.dev.local:8080"
@@ -524,6 +557,7 @@ mcp-coder coordinator --repo mcp_coder
 ```
 
 **Use cases:**
+
 - CI/CD pipelines (inject secrets via environment)
 - Testing with different Jenkins servers
 - Temporary credential overrides
@@ -559,22 +593,26 @@ mcp-coder coordinator --repo mcp_coder --force-refresh --log-level DEBUG
 #### CLI Flag Usage Examples
 
 **Normal operation (uses cache):**
+
 ```bash
 mcp-coder coordinator --repo mcp_coder
 ```
 
 **Force fresh data (bypass cache completely):**
+
 ```bash
 mcp-coder coordinator --repo mcp_coder --force-refresh
 ```
 
 **Multiple repositories with fresh data:**
+
 ```bash
 mcp-coder coordinator --repo repo_a --force-refresh
 mcp-coder coordinator --repo repo_b --force-refresh
 ```
 
 **Debug cache behavior:**
+
 ```bash
 mcp-coder coordinator --repo mcp_coder --log-level DEBUG
 ```
@@ -582,7 +620,7 @@ mcp-coder coordinator --repo mcp_coder --log-level DEBUG
 #### When to use `--force-refresh`
 
 | Scenario | Use `--force-refresh` | Reason |
-|----------|---------------------|--------|
+| ---------- | --------------------- | -------- |
 | **New issues created** | Yes | Ensure latest issues are included |
 | **Label changes** | Yes | Fresh label data needed |
 | **Milestone updates** | Yes | Current milestone assignments |
@@ -593,6 +631,7 @@ mcp-coder coordinator --repo mcp_coder --log-level DEBUG
 | **Troubleshooting** | Yes | Eliminate cache as variable |
 
 **Performance Impact:**
+
 - Without `--force-refresh`: 1-3 GitHub API calls (using cache)
 - With `--force-refresh`: 10-50+ GitHub API calls (fresh data)
 - Trade-off between data freshness and execution speed
@@ -657,26 +696,31 @@ When you trigger a coordinator test, Jenkins executes a comprehensive verificati
 The default test command performs the following checks:
 
 #### 1. Tool Verification
+
 - Verifies `mcp-coder` is installed and displays version
 - Verifies `mcp-tools-py` is installed
 - Verifies `mcp-workspace` is installed
 - Runs `mcp-coder verify` to check environment
 
 #### 2. Environment Setup
+
 - Sets `MCP_CODER_PROJECT_DIR=/workspace/repo`
 - Sets `MCP_CODER_VENV_DIR=/workspace/.venv`
 - Syncs dependencies using `uv sync --extra dev`
 
 #### 3. Claude CLI Verification
+
 - Verifies `claude` CLI is installed
 - Lists configured MCP servers with `claude mcp list`
 - Tests basic Claude functionality with simple prompt
 
 #### 4. MCP Coder Functionality
+
 - Tests MCP Coder with debug logging
 - Verifies prompt command works correctly
 
 #### 5. Virtual Environment
+
 - Activates project virtual environment
 - Re-verifies `mcp-coder` from within venv
 
@@ -757,6 +801,7 @@ dev = [
 ```
 
 This ensures:
+
 - Automated workflows install only type stubs (`uv sync --extra types`)
 - Local development installs everything (`pip install -e ".[dev]"`)
 
@@ -770,6 +815,7 @@ Add it to config file under [coordinator.repos.nonexistent_repo]
 ```
 
 **Solution:** Add repository configuration to config file:
+
 ```toml
 [coordinator.repos.nonexistent_repo]
 repo_url = "https://github.com/your-org/repo.git"
@@ -793,7 +839,9 @@ Set via environment variables (JENKINS_URL, JENKINS_USER, JENKINS_TOKEN) or conf
 ```
 
 **Solution:** Either:
+
 1. Add to config file:
+
    ```toml
    [jenkins]
    server_url = "https://jenkins.example.com:8080"
@@ -802,6 +850,7 @@ Set via environment variables (JENKINS_URL, JENKINS_USER, JENKINS_TOKEN) or conf
    ```
 
 2. Or set environment variables:
+
    ```bash
    export JENKINS_URL="https://jenkins.example.com:8080"
    export JENKINS_USER="your-username"
@@ -821,11 +870,13 @@ PermissionError: [Errno 13] Permission denied: '/home/user/.mcp_coder/config.tom
 #### Error: Stale or incorrect data
 
 **Symptoms:**
+
 - Coordinator missing recently created issues
 - Issue counts seem incorrect
 - Recent label changes not reflected
 
 **Solution:**
+
 ```bash
 # Force refresh to bypass cache
 mcp-coder coordinator --repo mcp_coder --force-refresh
@@ -834,11 +885,13 @@ mcp-coder coordinator --repo mcp_coder --force-refresh
 #### Error: Cache file corruption
 
 **Symptoms:**
+
 - JSON decode errors in logs
 - Coordinator fails with cache-related errors
 - Unexpected cache behavior
 
 **Solution:**
+
 ```bash
 # Clear cache directory (cache will rebuild automatically)
 rm -rf ~/.mcp_coder/cache/
@@ -852,11 +905,13 @@ mcp-coder coordinator --repo mcp_coder
 #### Performance: Cache not improving speed
 
 **Symptoms:**
+
 - Still making many GitHub API calls
 - No noticeable speed improvement
 - Cache files seem small or missing
 
 **Diagnosis:**
+
 ```bash
 # Check cache directory exists and has recent files
 ls -la ~/.mcp_coder/cache/
@@ -868,6 +923,7 @@ mcp-coder coordinator --repo mcp_coder --log-level DEBUG
 ```
 
 **Solutions:**
+
 - Ensure `cache_refresh_minutes` is set appropriately (not too low)
 - Check that repository URL in cache filename matches config
 - Verify sufficient disk space for cache files
@@ -875,10 +931,12 @@ mcp-coder coordinator --repo mcp_coder --log-level DEBUG
 #### Cache file locations
 
 **Default cache directory:**
+
 - **Linux/macOS:** `~/.mcp_coder/cache/`
 - **Windows:** `%USERPROFILE%\.mcp_coder\cache\`
 
 **Cache file naming:**
+
 - Format: `issues_cache_{owner}_{repo}.json`
 - Example: `issues_cache_myorg_myrepo.json`
 - Falls back to URL hash if repository parsing fails
@@ -886,6 +944,7 @@ mcp-coder coordinator --repo mcp_coder --log-level DEBUG
 #### Complete Configuration Examples
 
 **Standard Development Configuration:**
+
 ```toml
 [coordinator]
 # Cache GitHub API calls for 24 hours (recommended default)
@@ -903,6 +962,7 @@ github_credentials_id = "github-pat"
 ```
 
 **Active Development Environment:**
+
 ```toml
 [coordinator]
 # Refresh cache hourly for repositories with frequent issue updates
@@ -920,6 +980,7 @@ github_credentials_id = "github-dev-token"
 ```
 
 **Production Environment with Conservative Caching:**
+
 ```toml
 [coordinator]
 # Refresh cache every 48 hours for stable production repositories
@@ -937,6 +998,7 @@ github_credentials_id = "github-prod-pat"
 ```
 
 **Multi-Repository Configuration with Different Cache Settings:**
+
 ```toml
 [coordinator]
 # Default cache setting (applies to all repos unless overridden)
@@ -969,6 +1031,7 @@ github_credentials_id = "github-infra-pat"
 ## Security Best Practices
 
 ### API Tokens
+
 - ✅ Use API tokens (NOT passwords)
 - ✅ Store tokens in config file (user-only permissions)
 - ✅ Use environment variables in CI/CD
@@ -983,6 +1046,7 @@ github_credentials_id = "github-infra-pat"
    - GitHub credentials ID in Jenkins
 
 2. Add to config:
+
    ```toml
    [coordinator.repos.new_repo]
    repo_url = "https://github.com/org/new_repo.git"
@@ -991,6 +1055,7 @@ github_credentials_id = "github-infra-pat"
    ```
 
 3. Test:
+
    ```bash
    mcp-coder coordinator --repo new_repo --dry-run
    ```
@@ -998,12 +1063,15 @@ github_credentials_id = "github-infra-pat"
 ## Platform-Specific Notes
 
 ### Windows
+
 - Config path uses `%USERPROFILE%` (typically `C:\Users\YourName`)
 - Path separators are handled automatically
 - Use PowerShell or Command Prompt
 
 ### Docker/Containers
+
 Mount config directory as volume:
+
 ```bash
 docker run -v ~/.mcp_coder:/root/.mcp_coder my-container
 ```
@@ -1011,10 +1079,12 @@ docker run -v ~/.mcp_coder:/root/.mcp_coder my-container
 ## Related Documentation
 
 ### Setup and Usage
+
 - **[Repository Setup](../repository-setup/README.md)** - GitHub Actions, labels, and repository configuration
 - **[CLI Reference](../cli-reference.md)** - Complete command documentation
 - **[Development Process](../processes-prompts/development-process.md)** - Detailed workflow methodology
 
 ### Technical Documentation
+
 - **[Architecture Overview](../architecture/architecture.md)** - System architecture and design
 - **[Main README](../../README.md)** - Project overview and quick start

--- a/docs/getting-started/label-setup.md
+++ b/docs/getting-started/label-setup.md
@@ -276,16 +276,31 @@ The default workflow uses these status labels:
 
 | Label | Description |
 |-------|-------------|
-| `status-01:created` | Issue created, awaiting triage |
-| `status-02:awaiting-planning` | Ready for planning phase |
-| `status-03:planning-in-progress` | Currently being planned |
-| `status-04:plan-review` | Plan ready for review |
-| `status-05:plan-ready` | Plan approved, ready for implementation |
-| `status-06:implementation-in-progress` | Currently being implemented |
-| `status-07:code-review` | Code ready for review |
-| `status-08:ready-pr` | Ready for pull request |
-| `status-09:pr-in-progress` | PR being created |
+| `status-01:created` | Fresh issue, may need refinement |
+| `status-02:awaiting-planning` | Refined, ready for planning pickup |
+| `status-03:planning` | Plan being drafted (in progress) |
+| `status-04:plan-review` | Plan available for review |
+| `status-05:plan-ready` | Plan approved, ready to code |
+| `status-06:implementing` | Code being written (in progress) |
+| `status-07:code-review` | Implementation complete, needs review |
+| `status-08:ready-pr` | Approved for pull request creation |
+| `status-09:pr-creating` | Pull request being created (in progress) |
 | `status-10:pr-created` | PR created, awaiting merge |
+
+### Optional Automated Review Labels
+
+These labels are used only when automated review is enabled via `auto_review_plan` / `auto_review_implementation` (see [Configuration Guide](../configuration/config.md)). With the flags off (default) they go unused.
+
+| Label | Description |
+|-------|-------------|
+| `status-14:plan-review-bot` | Plan ready for automated review pickup |
+| `status-14i:plan-reviewing` | Plan being reviewed (auto/in-progress) |
+| `status-17:code-review-bot` | Implementation ready for automated review pickup |
+| `status-17i:code-reviewing` | Implementation being reviewed (auto/in-progress) |
+
+Automated review can also emit fine-grained failure labels (`status-14f-*` for plan review, `status-17f-*` for code review). See the [Failure Handling](../processes-prompts/development-process.md#8-failure-handling) table for the full list and recovery steps.
+
+The complete, authoritative label set (colors, categories, timeouts) is defined in [`config/labels.json`](../../src/mcp_coder/config/labels.json).
 
 ## Verification
 

--- a/docs/processes-prompts/development-process.md
+++ b/docs/processes-prompts/development-process.md
@@ -314,6 +314,8 @@ flowchart LR
 
 **📍 Position in Flow:** `status:plan-review` → **👤 Plan Review** → `status:plan-ready`
 
+> **Human or automated.** This review can run either as an interactive human session (the default flow described below) or fully automated via the `review-plan` workflow when `auto_review_plan` is enabled. See [Automated Review](#9-automated-review-optional).
+
 ```mermaid
 flowchart LR
     Input1[🏷️ status:plan-review]
@@ -730,6 +732,8 @@ This could benefit from `format_and_commit` tool.
 
 **📍 Position in Flow:** `status:code-review` → **👤 Code Review** → `status:ready-pr`
 
+> **Human or automated.** This review can run either as an interactive human session (the default flow described below) or fully automated via the `review-implementation` workflow when `auto_review_implementation` is enabled. See [Automated Review](#9-automated-review-optional).
+
 ```mermaid
 flowchart TD
     Input1["🏷️ status:code-review"]
@@ -1125,5 +1129,46 @@ Automated workflows can fail at several points. When a failure occurs, the issue
 | `status-06f-ci:ci-fix-needed` | CI exhausted 3 fix attempts | `mcp-coder gh-tool set-status status-05:plan-ready` |
 | `status-06f-timeout:llm-timeout` | LLM API timeout during implementation | `mcp-coder gh-tool set-status status-05:plan-ready` |
 | `status-09f:pr-creating-failed` | PR creation fails | `mcp-coder gh-tool set-status status-08:ready-pr` |
+| `status-14f:plan-review-failed` | Automated plan review failed (generic error / unparseable verdict) | `mcp-coder gh-tool set-status status-14:plan-review-bot` |
+| `status-14f-rounds:plan-review-rounds-exhausted` | Plan review hit the rounds cap (5) without converging | `mcp-coder gh-tool set-status status-14:plan-review-bot` |
+| `status-14f-timeout:plan-review-llm-timeout` | LLM API timeout during automated plan review | `mcp-coder gh-tool set-status status-14:plan-review-bot` |
+| `status-14f-mcp:plan-review-mcp-unavailable` | MCP server unavailable during automated plan review | `mcp-coder gh-tool set-status status-14:plan-review-bot` |
+| `status-17f:code-review-failed` | Automated code review failed (generic error / unparseable verdict) | `mcp-coder gh-tool set-status status-17:code-review-bot` |
+| `status-17f-ci:code-review-ci-fix-needed` | CI still red at the rounds cap | `mcp-coder gh-tool set-status status-17:code-review-bot` |
+| `status-17f-rounds:code-review-rounds-exhausted` | Code review hit the rounds cap (5) without converging | `mcp-coder gh-tool set-status status-17:code-review-bot` |
+| `status-17f-timeout:code-review-llm-timeout` | LLM API timeout during automated code review | `mcp-coder gh-tool set-status status-17:code-review-bot` |
+| `status-17f-mcp:code-review-mcp-unavailable` | MCP server unavailable during automated code review | `mcp-coder gh-tool set-status status-17:code-review-bot` |
 
 To recover from a failure, investigate the root cause (logs, CI output, API errors), resolve the underlying issue, then use `mcp-coder gh-tool set-status` to transition the issue back to a retry-ready state as shown in the table above. The bot will automatically pick up the issue again from the recovery status.
+
+The `status-14f-*` / `status-17f-*` labels only occur when automated review is enabled (`auto_review_plan` / `auto_review_implementation`; see [Automated Review](#9-automated-review-optional) below). Their recovery commands re-queue the automated review; to instead hand off to the interactive supervisor, set `status-04:plan-review` or `status-07:code-review`. Each carries a `/check_branch_status` vscodeclaude command so a human review session opens automatically.
+
+### 9. Automated Review (optional)
+
+Plan review (stage 4) and code review (stage 7) normally run as human-triggered vscodeclaude supervisor sessions. Two optional headless workflows — `review-plan` and `review-implementation` — automate them so the bot lane can review without a human, pulling one in only when needed.
+
+**Off by default.** Both are gated by per-repo config flags, `auto_review_plan` and `auto_review_implementation` (see [Configuration Guide](../configuration/config.md)), which default to `false`. With the flags off, behavior is identical to today: `create-plan` transitions to `status-04:plan-review` and `implement` to `status-07:code-review` for the interactive supervisor.
+
+**When enabled**, the create-plan / implement success transition instead targets a dedicated bot-pickup label, which the coordinator dispatches to the review workflow:
+
+```
+create-plan ──▶ status-14:plan-review-bot ──▶ (coordinator dispatches review-plan)
+                    ├─ success     → status-05:plan-ready
+                    ├─ needs-human → status-04:plan-review  (interactive supervisor)
+                    └─ error       → status-14f-*           (failure label)
+
+implement ────▶ status-17:code-review-bot ──▶ (coordinator dispatches review-implementation)
+                    ├─ success     → status-08:ready-pr
+                    ├─ needs-human → status-07:code-review  (interactive supervisor)
+                    └─ error       → status-17f-*           (failure label)
+```
+
+**How a review runs.** Each workflow runs a multi-round loop (rounds cap: 5) pairing a **fresh reviewer session per round** with a **persistent supervisor session**:
+
+1. The reviewer session (fresh each round) fetches the plan/diff, issue, and knowledge base via MCP tools and returns a structured findings report.
+2. The supervisor session (persistent across rounds) triages the report into a machine-readable verdict: `dismiss` (converged → success), `tasks` (fixes for the reviewer to apply via MCP edit tools), or `escalate` (a design/scope question → needs-human).
+3. On `tasks`, the reviewer applies the fixes; `review-implementation` then re-runs the shared rebase/CI steps. The loop repeats with a new reviewer session until convergence or the rounds cap.
+
+Every round appends a detailed log to `pr_info/plan_review_log_{n}.md` / `pr_info/implementation_review_log_{n}.md` — the source of truth for an escalation handoff (no separate issue comment is posted for escalations). Rebase-needed or still-red CI is a gate: it routes to needs-human or error, never success. Failure labels and their recovery are in the [Failure Handling](#8-failure-handling) table above.
+
+> **Quality gate before enabling.** Before setting `auto_review_*=true` on a repo, validate that the bot's review quality matches a trusted reference (the interactive supervisor or a human) on real branches. The deterministic behavior is unit-tested and the session interleave is integration-tested, but the model-judgment match is a manual pre-enable check, not something CI enforces.

--- a/docs/processes-prompts/development-process.md
+++ b/docs/processes-prompts/development-process.md
@@ -1141,7 +1141,7 @@ Automated workflows can fail at several points. When a failure occurs, the issue
 
 To recover from a failure, investigate the root cause (logs, CI output, API errors), resolve the underlying issue, then use `mcp-coder gh-tool set-status` to transition the issue back to a retry-ready state as shown in the table above. The bot will automatically pick up the issue again from the recovery status.
 
-The `status-14f-*` / `status-17f-*` labels only occur when automated review is enabled (`auto_review_plan` / `auto_review_implementation`; see [Automated Review](#9-automated-review-optional) below). Their recovery commands re-queue the automated review; to instead hand off to the interactive supervisor, set `status-04:plan-review` or `status-07:code-review`. Each carries a `/check_branch_status` vscodeclaude command so a human review session opens automatically.
+The `status-14f-*` / `status-17f-*` labels only occur when automated review is enabled (`auto_review_plan` / `auto_review_implementation`; see [Automated Review](#9-automated-review-optional) below). Their recovery commands re-queue the automated review; to instead hand off to the interactive supervisor, set `status-04:plan-review` or `status-07:code-review`. `status-04:plan-review` carries `/plan_review_supervisor` and `status-07:code-review` carries `/implementation_review_supervisor`, so a human review session opens automatically.
 
 ### 9. Automated Review (optional)
 

--- a/docs/processes-prompts/github_Issue_Workflow_Matrix.html
+++ b/docs/processes-prompts/github_Issue_Workflow_Matrix.html
@@ -218,6 +218,21 @@
         .status-ci-fix-needed { --label-color: #d93f0b; }
         .status-llm-timeout { --label-color: #e99695; }
         .status-pr-creating-failed { --label-color: #b60205; }
+
+        /* Optional automated-review lane */
+        .status-plan-review-bot { --label-color: #60a5fa; }
+        .status-plan-reviewing { --label-color: #bfdbfe; }
+        .status-code-review-bot { --label-color: #fbbf24; }
+        .status-code-reviewing { --label-color: #fed7aa; }
+        .status-plan-review-failed { --label-color: #b60205; }
+        .status-plan-review-rounds { --label-color: #b60205; }
+        .status-plan-review-timeout { --label-color: #e99695; }
+        .status-plan-review-mcp { --label-color: #e99695; }
+        .status-code-review-failed { --label-color: #b60205; }
+        .status-code-review-ci { --label-color: #d93f0b; }
+        .status-code-review-rounds { --label-color: #b60205; }
+        .status-code-review-timeout { --label-color: #e99695; }
+        .status-code-review-mcp { --label-color: #e99695; }
         
         /* Flow arrows inline */
         .flow-cell {
@@ -470,6 +485,130 @@
             <div class="cell-empty"></div>
         </div>
         
+        <!-- Optional: Automated Review Lane (branches from stages 4 & 7) -->
+        <div class="row-label" style="border-top: 2px dashed #cbd5e0; padding-top: 20px; margin-top: 25px;">Optional: Automated Review Lane <span style="font-weight: 400; font-style: italic; color: #718096;">— enabled per-repo via <code>auto_review_plan</code> / <code>auto_review_implementation</code> (default off)</span></div>
+        <div style="color: #718096; font-size: 0.9rem; line-height: 1.4; margin: 0 0 15px;">
+            When enabled, <code>create-plan</code> / <code>implement</code> route their success to the review-bot pickup label instead of the human review label. Each review ends in a 3-way outcome: <strong>success</strong> advances (→ <code>05:plan-ready</code> / <code>08:ready-pr</code>), <strong>needs-human</strong> reuses the interactive review label, <strong>error</strong> sets a failure label.
+        </div>
+
+        <!-- Row: Automated Plan Review (14 → 14i → 14f-*) -->
+        <div class="row-label">Automated Plan Review</div>
+        <div class="workflow-row">
+            <div class="label-card muted status-plan-review">
+                <div class="step-number">→4</div>
+                <div class="label-name">status-04:plan-review</div>
+                <div class="label-description">needs-human: escalation reuses the interactive supervisor</div>
+                <div class="status-badge badge-human">Escalate</div>
+            </div>
+
+            <div class="label-card status-plan-review-bot">
+                <div class="step-number">14</div>
+                <div class="label-name">status-14:plan-review-bot</div>
+                <div class="label-description">Plan ready for automated review pickup (success → 05:plan-ready)</div>
+                <div class="status-badge badge-pickup">Waiting</div>
+            </div>
+
+            <div class="label-card status-plan-reviewing">
+                <div class="step-number">14i</div>
+                <div class="label-name">status-14i:plan-reviewing</div>
+                <div class="label-description">Plan being reviewed (auto/in-progress)</div>
+                <div class="status-badge badge-busy">Working</div>
+            </div>
+
+            <div class="failed-stack">
+                <div class="label-card highlight-red status-plan-review-failed">
+                    <div class="step-number">14f</div>
+                    <div class="label-name">status-14f:plan-review-failed</div>
+                    <div class="label-description">General failure / unparseable verdict</div>
+                    <div class="status-badge badge-failed">Failed</div>
+                </div>
+                <div class="label-card highlight-red status-plan-review-rounds">
+                    <div class="step-number">14f-r</div>
+                    <div class="label-name">status-14f-rounds:plan-review-rounds-exhausted</div>
+                    <div class="label-description">Rounds cap (5) hit without converging</div>
+                    <div class="status-badge badge-failed">Rounds</div>
+                </div>
+                <div class="label-card highlight-red status-plan-review-timeout">
+                    <div class="step-number">14f-t</div>
+                    <div class="label-name">status-14f-timeout:plan-review-llm-timeout</div>
+                    <div class="label-description">LLM API timeout</div>
+                    <div class="status-badge badge-failed">Timeout</div>
+                </div>
+                <div class="label-card highlight-red status-plan-review-mcp">
+                    <div class="step-number">14f-m</div>
+                    <div class="label-name">status-14f-mcp:plan-review-mcp-unavailable</div>
+                    <div class="label-description">MCP server unavailable</div>
+                    <div class="status-badge badge-failed">MCP</div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Arrow row -->
+        <div class="row-arrow">
+            <div class="arrow-down">&#x2193;</div>
+            <div></div>
+            <div></div>
+            <div></div>
+        </div>
+
+        <!-- Row: Automated Code Review (17 → 17i → 17f-*) -->
+        <div class="row-label">Automated Code Review</div>
+        <div class="workflow-row">
+            <div class="label-card muted status-code-review">
+                <div class="step-number">→7</div>
+                <div class="label-name">status-07:code-review</div>
+                <div class="label-description">needs-human: escalation reuses the interactive supervisor</div>
+                <div class="status-badge badge-human">Escalate</div>
+            </div>
+
+            <div class="label-card status-code-review-bot">
+                <div class="step-number">17</div>
+                <div class="label-name">status-17:code-review-bot</div>
+                <div class="label-description">Implementation ready for automated review pickup (success → 08:ready-pr)</div>
+                <div class="status-badge badge-pickup">Waiting</div>
+            </div>
+
+            <div class="label-card status-code-reviewing">
+                <div class="step-number">17i</div>
+                <div class="label-name">status-17i:code-reviewing</div>
+                <div class="label-description">Implementation being reviewed (auto/in-progress)</div>
+                <div class="status-badge badge-busy">Working</div>
+            </div>
+
+            <div class="failed-stack">
+                <div class="label-card highlight-red status-code-review-failed">
+                    <div class="step-number">17f</div>
+                    <div class="label-name">status-17f:code-review-failed</div>
+                    <div class="label-description">General failure / unparseable verdict</div>
+                    <div class="status-badge badge-failed">Failed</div>
+                </div>
+                <div class="label-card highlight-red status-code-review-ci">
+                    <div class="step-number">17f-ci</div>
+                    <div class="label-name">status-17f-ci:code-review-ci-fix-needed</div>
+                    <div class="label-description">CI still red at the rounds cap</div>
+                    <div class="status-badge badge-failed">CI Failed</div>
+                </div>
+                <div class="label-card highlight-red status-code-review-rounds">
+                    <div class="step-number">17f-r</div>
+                    <div class="label-name">status-17f-rounds:code-review-rounds-exhausted</div>
+                    <div class="label-description">Rounds cap (5) hit without converging</div>
+                    <div class="status-badge badge-failed">Rounds</div>
+                </div>
+                <div class="label-card highlight-red status-code-review-timeout">
+                    <div class="step-number">17f-t</div>
+                    <div class="label-name">status-17f-timeout:code-review-llm-timeout</div>
+                    <div class="label-description">LLM API timeout</div>
+                    <div class="status-badge badge-failed">Timeout</div>
+                </div>
+                <div class="label-card highlight-red status-code-review-mcp">
+                    <div class="step-number">17f-m</div>
+                    <div class="label-name">status-17f-mcp:code-review-mcp-unavailable</div>
+                    <div class="label-description">MCP server unavailable</div>
+                    <div class="status-badge badge-failed">MCP</div>
+                </div>
+            </div>
+        </div>
+
         <!-- Color Reference -->
         <div class="color-reference">
             <h3 style="text-align: center; margin-bottom: 20px; color: #2d3748;">Color Reference</h3>

--- a/docs/processes-prompts/github_Issue_Workflow_Matrix.html
+++ b/docs/processes-prompts/github_Issue_Workflow_Matrix.html
@@ -704,6 +704,13 @@
                         <div class="color-hex">#e99695</div>
                     </div>
                 </div>
+                <div class="color-item">
+                    <div class="color-swatch" style="background-color: #60a5fa;"></div>
+                    <div class="color-info">
+                        <div class="color-name">Plan Review Bot</div>
+                        <div class="color-hex">#60a5fa</div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/docs/repository-setup/github.md
+++ b/docs/repository-setup/github.md
@@ -138,6 +138,10 @@ Default timeouts:
 | status-03:planning | 15 minutes |
 | status-06:implementing | 120 minutes |
 | status-09:pr-creating | 15 minutes |
+| status-14i:plan-reviewing | 30 minutes |
+| status-17i:code-reviewing | 120 minutes |
+
+The `status-14i` / `status-17i` labels are the in-progress states for the optional automated review workflows (enabled via `auto_review_plan` / `auto_review_implementation`).
 
 ## Base Branch Support for Issues
 


### PR DESCRIPTION
## Summary

Documents the automated plan-review / implementation-review workflows and the associated GitHub issue-workflow labels, and corrects several accuracy gaps found during review.

### Documentation added
- Automated review workflows, status transitions, and failure handling across `architecture.md`, `development-process.md`, `label-setup.md`, `github.md`, and the issue-workflow matrix (HTML).
- `review-plan` / `review-implementation` / `init` / `rebase` CLI reference and config gating flags.

### Accuracy fixes (from documentation review)
- `architecture.md`: importlinter contract count 22 → 20.
- `development-process.md`: name the correct supervisor commands (`/plan_review_supervisor`, `/implementation_review_supervisor`) for `status-04`/`status-07` instead of `/check_branch_status`.
- `cli-reference.md`: `init` deploys skills, knowledge base, and agents (not just skills).
- `config.md`: `[llm]` key `provider` → `default_provider` everywhere; documented `MCP_CODER_LLM_PROVIDER` and provider resolution order; added `executor_os` / `setup_commands_windows` / `setup_commands_linux` to `[coordinator.repos.*]`; synced the Configuration Template block to `create_default_config()` output.
- `github_Issue_Workflow_Matrix.html`: added the missing Plan Review Bot color swatch.

## Test plan
Documentation-only change (`.md` / `.html`); no code, tests, or CI affected. Label names, command names, defaults, and status transitions were cross-checked against the source (`labels.json`, CLI parsers, `user_config.py`, `.importlinter`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)