### PR TITLE
chore: general chore batch (ci permissions, black floor, file-size limit, skill flags)

### DIFF
--- a/.claude/skills/check_branch_status/SKILL.md
+++ b/.claude/skills/check_branch_status/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Check branch readiness including CI, rebase needs, tasks, and labels
-disable-model-invocation: true
 allowed-tools:
   - mcp__mcp-workspace__check_branch_status
 ---

--- a/.claude/skills/implementation_review/SKILL.md
+++ b/.claude/skills/implementation_review/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Code review of implementation with compact diff analysis
-disable-model-invocation: true
 allowed-tools:
   - mcp__mcp-workspace__git
   - mcp__mcp-workspace__check_branch_status

--- a/.claude/skills/issue_analyse/SKILL.md
+++ b/.claude/skills/issue_analyse/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Analyse GitHub issue requirements, feasibility, and implementation approaches
-disable-model-invocation: true
 argument-hint: "<issue-number>"
 allowed-tools:
   - mcp__mcp-workspace__github_issue_view
@@ -59,5 +58,3 @@ If the issue contains a `### Base Branch` section:
 - Potential implementation approaches
 - Questions that need clarification
 - Impact on existing code
-
-**Note:** This skill has `disable-model-invocation` — it can only be run by the user typing `/issue_analyse`.

--- a/.claude/skills/plan_review/SKILL.md
+++ b/.claude/skills/plan_review/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Review implementation plan for completeness, simplicity, and risks
-disable-model-invocation: true
 allowed-tools:
   - mcp__mcp-workspace__git
   - mcp__mcp-workspace__read_file

--- a/.claude/skills/plan_update/SKILL.md
+++ b/.claude/skills/plan_update/SKILL.md
@@ -1,6 +1,5 @@
 ---
 description: Update implementation plan files based on discussion
-disable-model-invocation: true
 allowed-tools:
   - mcp__mcp-workspace__read_file
   - mcp__mcp-workspace__save_file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-forbidden-folders:
     runs-on: ubuntu-latest

--- a/.mcp.json
+++ b/.mcp.json
@@ -28,6 +28,8 @@
         "${MCP_CODER_PROJECT_DIR}",
         "--log-level",
         "INFO",
+        "--file-size-limit",
+        "750",
         "--reference-project",
         "name=mcp-workspace,path=${USERPROFILE}\\Documents\\GitHub\\mcp-workspace,url=https://github.com/MarcusJellinghaus/mcp-workspace",
         "--reference-project",

--- a/.mcp.linux.json
+++ b/.mcp.linux.json
@@ -28,6 +28,8 @@
         "${MCP_CODER_PROJECT_DIR}",
         "--log-level",
         "INFO",
+        "--file-size-limit",
+        "750",
         "--reference-project",
         "name=mcp-workspace,path=${HOME}/Documents/GitHub/mcp-workspace,url=https://github.com/MarcusJellinghaus/mcp-workspace",
         "--reference-project",

--- a/.mcp.macos.json
+++ b/.mcp.macos.json
@@ -28,6 +28,8 @@
         "${MCP_CODER_PROJECT_DIR}",
         "--log-level",
         "INFO",
+        "--file-size-limit",
+        "750",
         "--reference-project",
         "name=mcp-workspace,path=${HOME}/Documents/GitHub/mcp-workspace,url=https://github.com/MarcusJellinghaus/mcp-workspace",
         "--reference-project",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "black>=23.0.0",
+    "black>=26.5.1",
     "isort>=5.12.0",
     "mcp-tools-py",
     "mcp-workspace",


### PR DESCRIPTION
@
Works through four sections of the general chore list.

## Changes

**1. `ci.yml` top-level permissions** — adds `permissions: contents: read` to drop default `GITHUB_TOKEN` scopes. No job in the workflow writes to the repo or the GitHub API.

**2. black floor 23.0.0 → 26.5.1** — aligns with mcp-tools-py (`1fd2a07`, PR #205) so installs converge on the same formatting output. Verified: black 26.5.1 leaves all 609 `src`/`tests` files unchanged, so no reformatting churn.

**3. mcp-workspace `--file-size-limit 750`** — makes `check_file_size` default to this repo`s CI limit instead of the built-in 600. Applied to `.mcp.json`, `.mcp.linux.json` and `.mcp.macos.json` (this repo has no `.mcp.windows.json`). Takes effect on next Claude Code launch.

**4. Supervisor-delegated skills made model-invocable** — removes `disable-model-invocation` from `implementation_review`, `check_branch_status`, `plan_review`, `plan_update` and `issue_analyse`, which the review/analysis supervisors delegate to engineer subagents; the flag made their own documented workflow unreachable. Also drops the now-false note line in `issue_analyse`. Every user-triggered skill keeps the flag.

## Notes

- Black is a **runtime** dependency here (not dev-only as in mcp-tools-py), so this raises the floor for all mcp-coder installs, not just contributors.
- The chore text referenced mcp-tools-py at `black>=26.5.1` while the local checkout still showed `24.10.0`; verified against the remote that `1fd2a07` is real before applying.

Part of #544
@